### PR TITLE
[FIX] Fix parser operator semantics for or/and continuations

### DIFF
--- a/crates/rsfga-domain/src/model/parser.rs
+++ b/crates/rsfga-domain/src/model/parser.rs
@@ -17,9 +17,9 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while, take_while1},
     character::complete::{char, multispace1, space0, space1},
-    combinator::{all_consuming, map, opt, recognize, value},
+    combinator::{all_consuming, map, opt, recognize, success, value},
     error::{context, ContextError, ParseError},
-    multi::{many0, separated_list1},
+    multi::{many0, many1, separated_list1},
     sequence::{delimited, pair, preceded, terminated, tuple},
     IResult,
 };
@@ -293,31 +293,32 @@ enum ContinuationResult {
 
 /// Parse additional or/and operands after a type constraint (respects precedence).
 /// Returns the operator type along with the operands to ensure correct semantics.
+///
+/// Uses idiomatic nom combinators: `alt` tries each parser in order, `many1` requires
+/// at least one match (failing allows `alt` to try next), `success` provides fallback.
 fn parse_userset_continuation<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     input: &'a str,
 ) -> IResult<&'a str, ContinuationResult, E> {
-    // Try parsing "or" operands first - each operand is at intersection level for proper precedence
-    let (rest, or_ops) = many0(preceded(
-        tuple((space0, tag("or"), space1)),
-        parse_intersection_level,
-    ))(input)?;
-
-    if !or_ops.is_empty() {
-        return Ok((rest, ContinuationResult::Or(or_ops)));
-    }
-
-    // Try parsing "and" operands
-    let (rest, and_ops) = many0(preceded(
-        tuple((space0, tag("and"), space1)),
-        parse_exclusion_or_base,
-    ))(input)?;
-
-    if !and_ops.is_empty() {
-        return Ok((rest, ContinuationResult::And(and_ops)));
-    }
-
-    // No continuations found
-    Ok((input, ContinuationResult::None))
+    alt((
+        // Try "or" operands first - each operand is at intersection level for proper precedence
+        map(
+            many1(preceded(
+                tuple((space0, tag("or"), space1)),
+                parse_intersection_level,
+            )),
+            ContinuationResult::Or,
+        ),
+        // Try "and" operands - each operand is at exclusion/base level
+        map(
+            many1(preceded(
+                tuple((space0, tag("and"), space1)),
+                parse_exclusion_or_base,
+            )),
+            ContinuationResult::And,
+        ),
+        // No continuations found
+        success(ContinuationResult::None),
+    ))(input)
 }
 
 // ============ Relation Definition Parser ============
@@ -352,16 +353,8 @@ fn parse_relation_definition<'a, E: ParseError<&'a str> + ContextError<&'a str>>
                 Option<Userset>,
                 ContinuationResult,
             )| {
-                let base_userset = if let Some(explicit_userset) = userset {
-                    // Explicit userset provided (e.g., "this" or "viewer from parent")
-                    explicit_userset
-                } else if type_constraint.is_some() {
-                    // Type constraint implies This
-                    Userset::This
-                } else {
-                    // No type constraint or userset, defaults to This
-                    Userset::This
-                };
+                // Base userset: explicit if provided, otherwise This (type constraint or default)
+                let base_userset = userset.unwrap_or(Userset::This);
 
                 // Combine base userset with continuations using the correct operator
                 let rewrite = match continuation {


### PR DESCRIPTION
## Summary

Fixes critical issues #21 and #22 where type constraints followed by `and` were incorrectly parsed as `Union` instead of `Intersection`.

**Before:** `[user] and admin` → `Union(This, admin)` ❌
**After:** `[user] and admin` → `Intersection(This, admin)` ✅

## Root Cause

`parse_userset_continuation` returned `Vec<Userset>` without tracking whether operands were `or` or `and`. The caller in `parse_relation_definition` always wrapped results in `Userset::Union`, ignoring `and` semantics entirely.

## Changes

- **Add `ContinuationResult` enum** - Tracks operator type along with operands:
  ```rust
  enum ContinuationResult {
      None,
      Or(Vec<Userset>),   // Union semantics
      And(Vec<Userset>),  // Intersection semantics
  }
  ```

- **Update `parse_userset_continuation`** - Returns `ContinuationResult` instead of `Vec<Userset>`

- **Update `parse_relation_definition`** - Pattern matches on continuation type:
  - `ContinuationResult::Or` → builds `Userset::Union`
  - `ContinuationResult::And` → builds `Userset::Intersection`

- **Add regression tests**:
  - `test_parser_type_constraint_with_and_produces_intersection`
  - `test_parser_type_constraint_with_or_produces_union`

## Test plan

- [x] All 111 domain tests pass
- [x] Clippy passes with no warnings
- [x] New regression tests verify correct behavior for both `or` and `and`

## Closes

- Closes #21
- Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relation-definition parsing so type-constraint continuations now produce intersection for "and" combinations and union for "or" combinations.

* **Tests**
  * Added tests verifying intersection/union behavior for type-constraint continuations and general operator combinations in relation definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->