### PR TITLE
[Issue #131] Disable resolver cache by default for safety

### DIFF
--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -35,6 +35,17 @@ const MAX_CORRELATION_ID_LENGTH: usize = 256;
 ///
 /// This service implements the OpenFGA gRPC API with support for parallel
 /// batch checks through the integrated BatchCheckHandler.
+///
+/// # Cache Safety
+///
+/// By default, caching is **disabled** for safety. Cached positive authorization
+/// decisions can serve stale results after tuple writes/deletes. To enable caching,
+/// explicitly set `CheckCacheConfig::enabled` to `true`:
+///
+/// ```rust,ignore
+/// let cache_config = CheckCacheConfig::default().with_enabled(true);
+/// let service = OpenFgaGrpcService::with_cache_config(storage, cache_config);
+/// ```
 pub struct OpenFgaGrpcService<S: DataStore> {
     storage: Arc<S>,
     /// The batch check handler with parallel execution and deduplication.
@@ -45,21 +56,38 @@ pub struct OpenFgaGrpcService<S: DataStore> {
 
 impl<S: DataStore> OpenFgaGrpcService<S> {
     /// Creates a new gRPC service instance with default cache configuration.
+    ///
+    /// Note: Caching is **disabled** by default for safety. Use `with_cache_config`
+    /// with an explicitly enabled config to enable caching.
     pub fn new(storage: Arc<S>) -> Self {
         Self::with_cache_config(storage, CheckCacheConfig::default())
     }
 
     /// Creates a new gRPC service instance with custom cache configuration.
+    ///
+    /// # Cache Safety
+    ///
+    /// If `cache_config.enabled` is `false` (the default), the cache will be created
+    /// but NOT attached to the resolver. This means authorization checks will always
+    /// hit storage, ensuring fresh results.
+    ///
+    /// If `cache_config.enabled` is `true`, the cache will be attached to the resolver.
+    /// This improves performance but cached results may be stale until TTL expires
+    /// or invalidation occurs.
     pub fn with_cache_config(storage: Arc<S>, cache_config: CheckCacheConfig) -> Self {
         // Create adapters to bridge storage to domain traits
         let tuple_reader = Arc::new(DataStoreTupleReader::new(Arc::clone(&storage)));
         let model_reader = Arc::new(DataStoreModelReader::new(Arc::clone(&storage)));
 
         // Create the check cache
-        let cache = Arc::new(CheckCache::new(cache_config));
+        let cache = Arc::new(CheckCache::new(cache_config.clone()));
 
-        // Create the graph resolver with cache integration
-        let resolver_config = ResolverConfig::default().with_cache(Arc::clone(&cache));
+        // Create the graph resolver - only attach cache if explicitly enabled
+        let resolver_config = if cache_config.enabled {
+            ResolverConfig::default().with_cache(Arc::clone(&cache))
+        } else {
+            ResolverConfig::default()
+        };
         let resolver = Arc::new(GraphResolver::with_config(
             Arc::clone(&tuple_reader),
             Arc::clone(&model_reader),

--- a/crates/rsfga-api/src/http/state.rs
+++ b/crates/rsfga-api/src/http/state.rs
@@ -26,6 +26,17 @@ use crate::adapters::{DataStoreModelReader, DataStoreTupleReader};
 ///
 /// This allows the `GraphResolver` and `BatchCheckHandler` to work with
 /// any storage backend that implements `DataStore`.
+///
+/// # Cache Safety
+///
+/// By default, caching is **disabled** for safety. Cached positive authorization
+/// decisions can serve stale results after tuple writes/deletes. To enable caching,
+/// explicitly set `CheckCacheConfig::enabled` to `true`:
+///
+/// ```rust,ignore
+/// let cache_config = CheckCacheConfig::default().with_enabled(true);
+/// let state = AppState::with_cache_config(storage, cache_config);
+/// ```
 #[derive(Clone)]
 pub struct AppState<S: DataStore> {
     /// The storage backend.
@@ -34,27 +45,44 @@ pub struct AppState<S: DataStore> {
     pub batch_handler: Arc<BatchCheckHandler<DataStoreTupleReader<S>, DataStoreModelReader<S>>>,
     /// The graph resolver for single checks.
     pub resolver: Arc<GraphResolver<DataStoreTupleReader<S>, DataStoreModelReader<S>>>,
-    /// The check result cache.
+    /// The check result cache (always created, but only attached to resolver if enabled).
     pub cache: Arc<CheckCache>,
 }
 
 impl<S: DataStore> AppState<S> {
     /// Creates a new application state with default cache configuration.
+    ///
+    /// Note: Caching is **disabled** by default for safety. Use `with_cache_config`
+    /// with an explicitly enabled config to enable caching.
     pub fn new(storage: Arc<S>) -> Self {
         Self::with_cache_config(storage, CheckCacheConfig::default())
     }
 
     /// Creates a new application state with custom cache configuration.
+    ///
+    /// # Cache Safety
+    ///
+    /// If `cache_config.enabled` is `false` (the default), the cache will be created
+    /// but NOT attached to the resolver. This means authorization checks will always
+    /// hit storage, ensuring fresh results.
+    ///
+    /// If `cache_config.enabled` is `true`, the cache will be attached to the resolver.
+    /// This improves performance but cached results may be stale until TTL expires
+    /// or invalidation occurs.
     pub fn with_cache_config(storage: Arc<S>, cache_config: CheckCacheConfig) -> Self {
         // Create adapters to bridge storage to domain traits
         let tuple_reader = Arc::new(DataStoreTupleReader::new(Arc::clone(&storage)));
         let model_reader = Arc::new(DataStoreModelReader::new(Arc::clone(&storage)));
 
         // Create the check cache
-        let cache = Arc::new(CheckCache::new(cache_config));
+        let cache = Arc::new(CheckCache::new(cache_config.clone()));
 
-        // Create the graph resolver with cache integration
-        let resolver_config = ResolverConfig::default().with_cache(Arc::clone(&cache));
+        // Create the graph resolver - only attach cache if explicitly enabled
+        let resolver_config = if cache_config.enabled {
+            ResolverConfig::default().with_cache(Arc::clone(&cache))
+        } else {
+            ResolverConfig::default()
+        };
         let resolver = Arc::new(GraphResolver::with_config(
             Arc::clone(&tuple_reader),
             Arc::clone(&model_reader),


### PR DESCRIPTION
## Summary

- **Disables resolver cache by default** for safety - cached positive auth decisions can serve stale results after tuple writes/deletes
- Users must now explicitly opt-in to enable caching via `CheckCacheConfig::default().with_enabled(true)`
- Adds comprehensive documentation about cache safety implications

## Changes

1. **`CheckCacheConfig`** (`crates/rsfga-domain/src/cache/mod.rs`):
   - Added `enabled: bool` field (defaults to `false`)
   - Added builder methods: `with_enabled()`, `with_max_capacity()`, `with_ttl()`
   - Added `is_enabled()` accessor to `CheckCache`
   - Added tests: `test_cache_disabled_by_default`, `test_cache_can_be_explicitly_enabled`

2. **`AppState`** (`crates/rsfga-api/src/http/state.rs`):
   - Modified `with_cache_config()` to only attach cache to resolver when `enabled`
   - Added safety documentation

3. **`OpenFgaGrpcService`** (`crates/rsfga-api/src/grpc/service.rs`):
   - Same change as AppState
   - Added safety documentation

## Why This Change

From PR #128 review feedback:
- Cached positive authorization decisions (`allowed=true`) can serve stale results
- Until write-path invalidation is properly wired, enabling cache by default is unsafe
- This is a security concern per Invariant I1 (Correctness over Performance)

## Usage

```rust
// Before: Cache enabled by default (unsafe)
let state = AppState::new(storage);

// After: Cache disabled by default (safe)
let state = AppState::new(storage); // No caching

// Explicit opt-in for caching
let config = CheckCacheConfig::default().with_enabled(true);
let state = AppState::with_cache_config(storage, config);
```

## Test plan

- [x] All library tests pass (`cargo test --lib --workspace`)
- [x] Clippy passes with no warnings
- [x] Code formatted
- [x] New tests added for enabled flag behavior

## Related Issues

Fixes #131
Closes #130 (services already had cache handle - verified)
Closes #129 (CacheKey simplification already done in #128 - verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Caching is now disabled by default for enhanced safety; users can opt-in by explicitly enabling via configuration methods.
  * Added flexible cache configuration options including max capacity and time-to-live settings.

* **Documentation**
  * Expanded cache safety documentation clarifying default behavior and enablement instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->