### PR TITLE
[Issues #78 #79] Improve CEL error handling with structured error types

### DIFF
--- a/crates/rsfga-domain/src/cel/error.rs
+++ b/crates/rsfga-domain/src/cel/error.rs
@@ -43,4 +43,13 @@ pub enum CelError {
         /// Duration in milliseconds before timeout
         duration_ms: u64,
     },
+
+    /// Failed to build CEL context
+    #[error("Failed to add variable '{name}' to CEL context: {message}")]
+    ContextError {
+        /// The variable name that failed to be added
+        name: String,
+        /// Description of the error
+        message: String,
+    },
 }

--- a/crates/rsfga-domain/src/cel/expression.rs
+++ b/crates/rsfga-domain/src/cel/expression.rs
@@ -122,7 +122,7 @@ impl CelExpression {
     /// assert!(result.is_truthy());
     /// ```
     pub fn evaluate(&self, context: &CelContext) -> CelResult<EvalResult> {
-        let cel_ctx = context.to_cel_context();
+        let cel_ctx = context.to_cel_context()?;
 
         // Execute the program with the context
         let result = self
@@ -189,7 +189,7 @@ impl CelExpression {
         // The Program is wrapped in Arc and is Send+Sync, so we can share it
         // across threads without re-parsing.
         let eval_future = tokio::task::spawn_blocking(move || {
-            let cel_ctx = ctx_data.to_cel_context();
+            let cel_ctx = ctx_data.to_cel_context()?;
             let result = program
                 .execute(&cel_ctx)
                 .map_err(|e| CelError::EvaluationError {

--- a/crates/rsfga-domain/src/model/mod.rs
+++ b/crates/rsfga-domain/src/model/mod.rs
@@ -12,6 +12,6 @@ mod types_proptest;
 
 pub use parser::{parse, ParserError, ParserResult};
 pub use types::{
-    AuthorizationModel, Condition, ConditionParameter, Object, Relation, RelationDefinition, Store,
-    Tuple, TypeConstraint, TypeDefinition, User, Userset,
+    AuthorizationModel, Condition, ConditionError, ConditionParameter, Object, Relation,
+    RelationDefinition, Store, Tuple, TypeConstraint, TypeDefinition, User, Userset,
 };

--- a/crates/rsfga-domain/src/model/parser.rs
+++ b/crates/rsfga-domain/src/model/parser.rs
@@ -25,8 +25,8 @@ use nom::{
 };
 
 use super::{
-    AuthorizationModel, Condition, ConditionParameter, RelationDefinition, TypeConstraint,
-    TypeDefinition, Userset,
+    AuthorizationModel, Condition, ConditionError, ConditionParameter, RelationDefinition,
+    TypeConstraint, TypeDefinition, Userset,
 };
 
 /// Parser error type with context for better error messages.
@@ -496,7 +496,7 @@ fn parse_brace_balanced_expression<'a, E: ParseError<&'a str>>(
 /// Parse condition definition: condition name(params) { expression }
 fn parse_condition_definition<
     'a,
-    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, &'static str>,
+    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, ConditionError>,
 >(
     input: &'a str,
 ) -> IResult<&'a str, Condition, E> {
@@ -548,7 +548,7 @@ fn parse_condition_definition<
 /// Parse a model element (either a condition or a type definition)
 fn parse_model_element<
     'a,
-    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, &'static str>,
+    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, ConditionError>,
 >(
     input: &'a str,
 ) -> IResult<&'a str, ModelElement, E> {
@@ -567,7 +567,7 @@ enum ModelElement {
 /// Parse a complete authorization model
 fn parse_model<
     'a,
-    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, &'static str>,
+    E: ParseError<&'a str> + ContextError<&'a str> + FromExternalError<&'a str, ConditionError>,
 >(
     input: &'a str,
 ) -> IResult<&'a str, AuthorizationModel, E> {


### PR DESCRIPTION
## Summary

- Add `ConditionError` enum with `EmptyName`, `EmptyExpression`, `InvalidParameter` variants for condition validation errors (#79)
- Add `CelError::ContextError` variant for CEL context building failures (#78)
- Update `to_cel_context()` to return `Result<Context, CelError>` instead of using `.expect()` which could panic
- Update parser to use `FromExternalError<&str, ConditionError>` trait bound
- Update all callers in `expression.rs` to propagate errors properly

Closes #78
Closes #79

## Test plan

- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in CEL context operations to prevent panics and provide clear, descriptive error messages instead.
  * Enhanced condition validation with structured error types and detailed failure reporting.

* **New Features**
  * Added detailed error messages for condition and CEL context failures, enabling better diagnosis of configuration issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->