### PR TITLE
[Issues #34 #35] Improve gRPC test infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-health",
+ "url",
  "urlencoding",
  "uuid",
 ]

--- a/crates/compatibility-tests/Cargo.toml
+++ b/crates/compatibility-tests/Cargo.toml
@@ -18,6 +18,7 @@ tonic = { workspace = true }
 tonic-health = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+url = "2.5"
 urlencoding = "2.1"
 
 [dev-dependencies]

--- a/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
+++ b/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
@@ -1,51 +1,8 @@
 mod common;
 
 use anyhow::Result;
-use common::{get_grpc_url, grpc_call};
+use common::{grpc_call, grpcurl_describe, grpcurl_list};
 use serde_json::json;
-use std::process::Command;
-
-// ============================================================================
-// Section 21: gRPC Service Setup Tests
-// ============================================================================
-//
-// These tests verify basic gRPC connectivity and service availability.
-// We use grpcurl for simplicity - it uses gRPC reflection to discover and
-// call services without needing compiled protobuf stubs.
-//
-// ============================================================================
-
-/// Helper to list gRPC services
-fn grpcurl_list() -> Result<Vec<String>> {
-    let url = get_grpc_url();
-    let output = Command::new("grpcurl")
-        .args(["-plaintext", &url, "list"])
-        .output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("grpcurl list failed: {}", stderr);
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let services: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
-    Ok(services)
-}
-
-/// Helper to describe a gRPC service/method
-fn grpcurl_describe(target: &str) -> Result<String> {
-    let url = get_grpc_url();
-    let output = Command::new("grpcurl")
-        .args(["-plaintext", &url, "describe", target])
-        .output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("grpcurl describe failed: {}", stderr);
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
 
 // ============================================================================
 // Tests


### PR DESCRIPTION
## Summary

- Fix brittle `get_grpc_url` implementation (#35):
  - Use proper URL parsing with the `url` crate instead of string replacement
  - Support `OPENFGA_GRPC_URL` environment variable for direct configuration
  - Derive gRPC port from HTTP port (+1) instead of hardcoded `:18080` replacement
  - Handle edge cases with fallback logic for malformed URLs

- Consolidate gRPC helpers to `common/mod.rs` (#34):
  - Move `grpcurl_list()` from `test_section_21_grpc_setup.rs`
  - Move `grpcurl_describe()` from `test_section_21_grpc_setup.rs`
  - Move `grpc_call_with_error()` from `test_section_23_grpc_features.rs`
  - Update test files to use consolidated helpers
  - Remove duplicate `std::process::Command` imports

Closes #34
Closes #35

## Test plan

- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a URL parsing dependency to test infrastructure.
  * Consolidated gRPC test utilities into a shared module for reuse.

* **Tests**
  * Enhanced gRPC testing with robust URL resolution, default-port handling, and fallbacks.
  * Added unit tests for environment-based URL resolution.
  * Added utilities to list/describe gRPC services, capture grpc error output, and build/verify permission requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->