### PR TITLE
[Issues #36 #39 #40 #41] Improve test assertion robustness

### DIFF
--- a/crates/compatibility-tests/tests/test_section_17_error_format.rs
+++ b/crates/compatibility-tests/tests/test_section_17_error_format.rs
@@ -57,9 +57,11 @@ async fn test_400_bad_request_format() -> Result<()> {
         "Invalid format should return validation_error code"
     );
 
-    // Verify message contains useful information
+    // Verify message contains useful information (case-insensitive)
     assert!(
-        error.message.contains("StoreId"),
+        error.message.to_lowercase().contains("storeid")
+            || error.message.to_lowercase().contains("store_id")
+            || error.message.to_lowercase().contains("store id"),
         "Error message should reference the invalid field: {}",
         error.message
     );
@@ -341,14 +343,15 @@ async fn test_validation_errors_include_field_details() -> Result<()> {
     let error1: ErrorResponse = response1.json().await?;
     assert_eq!(error1.code, "validation_error");
 
-    // Error message should mention the missing/invalid fields
+    // Error message should mention the missing/invalid fields (case-insensitive)
+    let message_lower = error1.message.to_lowercase();
     assert!(
-        error1.message.contains("Relation") || error1.message.contains("relation"),
+        message_lower.contains("relation"),
         "Error should mention missing relation field: {}",
         error1.message
     );
     assert!(
-        error1.message.contains("Object") || error1.message.contains("object"),
+        message_lower.contains("object"),
         "Error should mention missing object field: {}",
         error1.message
     );
@@ -392,7 +395,7 @@ async fn test_validation_errors_include_field_details() -> Result<()> {
     let error3: ErrorResponse = response3.json().await?;
     assert_eq!(error3.code, "validation_error");
     assert!(
-        error3.message.contains("Name"),
+        error3.message.to_lowercase().contains("name"),
         "Error should mention the Name field: {}",
         error3.message
     );

--- a/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
+++ b/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
@@ -379,10 +379,13 @@ async fn test_can_call_check_service_methods() -> Result<()> {
     // Assert: Should return allowed: false
     // Note: gRPC/protobuf omits fields with default values, so "allowed": false
     // may appear as missing (empty object) or as explicit false
-    let allowed = check_response2
-        .get("allowed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false); // Default to false if field is missing
+    // However, if "allowed" is present, it MUST be a boolean
+    let allowed = match check_response2.get("allowed") {
+        Some(v) => v
+            .as_bool()
+            .expect("'allowed' field must be a boolean when present"),
+        None => false, // Protobuf default: missing field means false
+    };
 
     assert!(
         !allowed,

--- a/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
+++ b/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
@@ -443,16 +443,21 @@ async fn test_grpc_batch_check_matches_rest() -> Result<()> {
     );
 
     // check-2 should be denied (allowed: false or field omitted due to protobuf default)
-    let grpc_allowed2 = grpc_result["check-2"]
-        .get("allowed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    // If "allowed" is present, it MUST be a boolean; if missing, it means false (protobuf default)
+    let grpc_allowed2 = match grpc_result["check-2"].get("allowed") {
+        Some(v) => v
+            .as_bool()
+            .expect("gRPC 'allowed' field must be a boolean when present"),
+        None => false,
+    };
     assert!(!grpc_allowed2, "gRPC check-2 should be denied");
 
-    let rest_allowed2 = rest_result["check-2"]
-        .get("allowed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let rest_allowed2 = match rest_result["check-2"].get("allowed") {
+        Some(v) => v
+            .as_bool()
+            .expect("REST 'allowed' field must be a boolean when present"),
+        None => false,
+    };
     assert!(!rest_allowed2, "REST check-2 should be denied");
 
     // Assert parity: gRPC and REST should return the same denied result


### PR DESCRIPTION
## Summary
- Fixes #36: rest_call already checks HTTP status codes (verified - no changes needed)
- Fixes #39: Make error message checking case-insensitive to handle different implementations' capitalization
- Fixes #40: Verify 400 errors are actually duplicate tuple errors by parsing and checking the error code
- Fixes #41: Replace `unwrap_or(false)` with explicit match that validates 'allowed' field type while accepting protobuf default behavior

## Changes

### Issue #39 - Brittle error message checking
Changed assertions like `error.message.contains("StoreId")` to use case-insensitive matching:
```rust
error.message.to_lowercase().contains("storeid")
    || error.message.to_lowercase().contains("store_id")
```

### Issue #40 - HTTP 400 handling could mask errors
Now parses 400 response body and verifies the error code is actually `write_failed_due_to_invalid_input` or `cannot_allow_duplicate_tuples_in_one_request` instead of treating any 400 as expected.

### Issue #41 - unwrap_or(false) could mask API regressions
Changed from:
```rust
response.get("allowed").and_then(|v| v.as_bool()).unwrap_or(false)
```
To:
```rust
match response.get("allowed") {
    Some(v) => v.as_bool().expect("'allowed' field must be a boolean when present"),
    None => false, // Protobuf default: missing field means false
}
```

This accepts missing field (valid protobuf behavior) but fails if the field exists with wrong type.

## Test plan
- [x] All quality gates pass (fmt, clippy)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error message validation to be case-insensitive across compatibility tests.
  * Enhanced error classification for concurrent write operations to better distinguish duplicate tuple errors from other validation failures.
  * Strengthened type validation for response fields to ensure correct data types and catch type mismatches earlier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->