### PR TITLE
[Enhancement] Add metrics instrumentation to CEL expression cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "futures",
+ "metrics",
  "mockall",
  "moka",
  "nom",

--- a/crates/rsfga-api/src/observability/metrics.rs
+++ b/crates/rsfga-api/src/observability/metrics.rs
@@ -107,6 +107,9 @@ fn register_default_metrics() {
         "rsfga_storage_operation_duration_seconds",
         "Storage operation duration in seconds"
     );
+
+    // Register CEL cache metrics
+    rsfga_domain::cel::register_cel_cache_metrics();
 }
 
 /// Prometheus exposition format content type.

--- a/crates/rsfga-domain/Cargo.toml
+++ b/crates/rsfga-domain/Cargo.toml
@@ -36,6 +36,9 @@ cel-interpreter = { workspace = true }
 # Tracing
 tracing = { workspace = true }
 
+# Metrics
+metrics = { workspace = true }
+
 # Time handling (for Store timestamps - consistent with rsfga-storage)
 chrono = { workspace = true }
 

--- a/crates/rsfga-domain/src/cel/mod.rs
+++ b/crates/rsfga-domain/src/cel/mod.rs
@@ -38,7 +38,7 @@ mod context;
 mod error;
 mod expression;
 
-pub use cache::{global_cache, CelCacheConfig, CelExpressionCache};
+pub use cache::{global_cache, register_cel_cache_metrics, CelCacheConfig, CelExpressionCache};
 pub use context::{CelContext, CelResult as EvalResult, CelValue};
 pub use error::CelError;
 pub use expression::CelExpression;


### PR DESCRIPTION
## Summary

Add Prometheus-compatible metrics to the CEL expression cache for monitoring cache performance in production.

## Metrics Added

| Metric | Type | Description |
|--------|------|-------------|
| `rsfga_cel_cache_hits_total` | Counter | Number of cache hits |
| `rsfga_cel_cache_misses_total` | Counter | Number of cache misses |
| `rsfga_cel_cache_size` | Gauge | Current number of cached expressions |
| `rsfga_cel_cache_parse_duration_seconds` | Histogram | Time to parse new expressions (on cache miss) |

## Implementation Details

- **rsfga-domain/Cargo.toml**: Added `metrics` dependency
- **cel/cache.rs**:
  - Instrumented `get_or_parse()` with hit/miss counters and parse duration histogram
  - Instrumented `invalidate()` and `invalidate_all()` to update size gauge
  - Added `register_cel_cache_metrics()` function for metric descriptions
- **rsfga-api/observability/metrics.rs**: Integrated CEL cache metrics registration

## Example Prometheus Queries

```promql
# Cache hit ratio
sum(rate(rsfga_cel_cache_hits_total[5m])) / 
(sum(rate(rsfga_cel_cache_hits_total[5m])) + sum(rate(rsfga_cel_cache_misses_total[5m])))

# Parse latency p99
histogram_quantile(0.99, rate(rsfga_cel_cache_parse_duration_seconds_bucket[5m]))

# Current cache utilization
rsfga_cel_cache_size
```

## Tests Added

- `test_metrics_registration_doesnt_panic` - Verifies metrics registration works
- `test_cache_operations_emit_metrics` - Verifies cache operations emit metrics without errors

## Closes

Closes #108

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CEL cache now emits Prometheus metrics for monitoring cache performance, including hit/miss rates, parse duration, and current cache size, enabling better observability and performance tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->