### PR TITLE
Fix #42: Update validation module docs to match implementation

### DIFF
--- a/crates/rsfga-domain/src/validation/mod.rs
+++ b/crates/rsfga-domain/src/validation/mod.rs
@@ -1,10 +1,13 @@
 //! Authorization model validation.
 //!
 //! Validates that authorization models are semantically correct:
+//! - Model has at least one type definition (not empty)
 //! - No cyclic relation definitions
 //! - All referenced types exist
 //! - All referenced relations exist
-//! - Type constraints are satisfied
+//! - Type constraints are satisfied (including `type#relation` format)
+//! - All referenced conditions exist in the model
+//! - All condition expressions are valid CEL syntax
 
 use std::collections::{HashMap, HashSet};
 


### PR DESCRIPTION
## Summary
- Updated validation module documentation to accurately reflect all implemented validations
- The docs previously listed 4 validations but the implementation performs 7

## Changes
Added to documentation:
- Model has at least one type definition (not empty)
- All referenced conditions exist in the model
- All condition expressions are valid CEL syntax

Updated for clarity:
- Type constraints include `type#relation` format validation

## Test plan
- [x] All 16 existing validation tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)