### PR TITLE
Fix uninlined_format_args clippy warnings for Rust 1.88.0 CI

### DIFF
--- a/crates/compatibility-tests/tests/common/mod.rs
+++ b/crates/compatibility-tests/tests/common/mod.rs
@@ -158,7 +158,7 @@ pub fn get_grpc_url() -> String {
             // If the scheme is unknown, fall back to OpenFGA's default port 18080
             let http_port = parsed.port_or_known_default().unwrap_or(18080);
             let grpc_port = http_port + 1;
-            format!("{}:{}", host, grpc_port)
+            format!("{host}:{grpc_port}")
         }
         Err(_) => {
             // Fallback: try to extract host:port manually for malformed URLs
@@ -585,9 +585,9 @@ pub async fn write_sequential_tuples(store_id: &str, count: usize) -> Result<()>
     let tuples: Vec<_> = (0..count)
         .map(|i| {
             (
-                format!("user:user{}", i),
+                format!("user:user{i}"),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
             )
         })
         .collect();
@@ -649,7 +649,7 @@ pub fn grpc_call(method: &str, data: &serde_json::Value) -> Result<serde_json::V
     if !output.status.success() {
         // Always fail when grpcurl exits with non-zero status.
         // Tests that need to inspect error responses should use grpc_call_with_error.
-        anyhow::bail!("grpcurl failed: {} {}", stderr, stdout);
+        anyhow::bail!("grpcurl failed: {stderr} {stdout}");
     }
 
     if stdout.trim().is_empty() {
@@ -740,7 +740,7 @@ pub fn grpc_streaming_call(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("grpcurl streaming call failed: {}", stderr);
+        anyhow::bail!("grpcurl streaming call failed: {stderr}");
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -801,7 +801,7 @@ pub fn grpcurl_list() -> Result<Vec<String>> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("grpcurl list failed: {}", stderr);
+        anyhow::bail!("grpcurl list failed: {stderr}");
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -829,7 +829,7 @@ pub fn grpcurl_describe(target: &str) -> Result<String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("grpcurl describe failed: {}", stderr);
+        anyhow::bail!("grpcurl describe failed: {stderr}");
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())

--- a/crates/compatibility-tests/tests/test_section_1.rs
+++ b/crates/compatibility-tests/tests/test_section_1.rs
@@ -36,7 +36,7 @@ async fn test_can_start_openfga_via_docker_compose() -> Result<()> {
 fn start_docker_compose() -> Result<()> {
     // Get path to compatibility-tests crate root
     let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let compose_file = format!("{}/docker-compose.yml", crate_root);
+    let compose_file = format!("{crate_root}/docker-compose.yml");
 
     let output = Command::new("docker-compose")
         .args(["-f", &compose_file, "up", "-d"])
@@ -60,7 +60,7 @@ fn start_docker_compose() -> Result<()> {
 fn stop_docker_compose() -> Result<()> {
     // Get path to compatibility-tests crate root
     let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let compose_file = format!("{}/docker-compose.yml", crate_root);
+    let compose_file = format!("{crate_root}/docker-compose.yml");
 
     let output = Command::new("docker-compose")
         .args([
@@ -107,7 +107,7 @@ fn stop_docker_compose() -> Result<()> {
 fn check_openfga_running() -> Result<bool> {
     // Get path to compatibility-tests crate root
     let crate_root = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let compose_file = format!("{}/docker-compose.yml", crate_root);
+    let compose_file = format!("{crate_root}/docker-compose.yml");
 
     let output = Command::new("docker-compose")
         .args([
@@ -259,7 +259,7 @@ async fn test_can_clean_up_test_stores() -> Result<()> {
 
     // Act: Delete the store
     let delete_response = client
-        .delete(format!("http://localhost:18080/stores/{}", store_id))
+        .delete(format!("http://localhost:18080/stores/{store_id}"))
         .send()
         .await?;
 
@@ -272,7 +272,7 @@ async fn test_can_clean_up_test_stores() -> Result<()> {
 
     // Verify: Store no longer exists (GET should return 404)
     let get_response = client
-        .get(format!("http://localhost:18080/stores/{}", store_id))
+        .get(format!("http://localhost:18080/stores/{store_id}"))
         .send()
         .await?;
 

--- a/crates/compatibility-tests/tests/test_section_12_batch_check.rs
+++ b/crates/compatibility-tests/tests/test_section_12_batch_check.rs
@@ -67,10 +67,7 @@ async fn test_batch_check_multiple_tuples() -> Result<()> {
     let status = response.status();
     if !status.is_success() {
         let error_body = response.text().await?;
-        panic!(
-            "Batch check should succeed, got status: {}. Response: {}",
-            status, error_body
-        );
+        panic!("Batch check should succeed, got status: {status}. Response: {error_body}");
     }
 
     let response_body: serde_json::Value = response.json().await?;
@@ -340,9 +337,9 @@ async fn test_batch_check_large_batch() -> Result<()> {
     let tuples: Vec<_> = (0..MAX_BATCH_SIZE)
         .map(|i| {
             (
-                format!("user:user{}", i),
+                format!("user:user{i}"),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
             )
         })
         .collect();
@@ -402,9 +399,7 @@ async fn test_batch_check_large_batch() -> Result<()> {
     assert_eq!(
         results.len(),
         MAX_BATCH_SIZE,
-        "Batch check should return {} results for {} checks",
-        MAX_BATCH_SIZE,
-        MAX_BATCH_SIZE
+        "Batch check should return {MAX_BATCH_SIZE} results for {MAX_BATCH_SIZE} checks"
     );
 
     // Assert: All should be allowed
@@ -414,8 +409,7 @@ async fn test_batch_check_large_batch() -> Result<()> {
 
     assert!(
         all_allowed,
-        "All {} checks should return allowed=true",
-        MAX_BATCH_SIZE
+        "All {MAX_BATCH_SIZE} checks should return allowed=true"
     );
 
     Ok(())
@@ -494,10 +488,7 @@ async fn test_batch_check_deduplication() -> Result<()> {
 
     // Note: We can't definitively verify deduplication without internal metrics,
     // but if this completes quickly (< 100ms), it likely deduplicated
-    println!(
-        "Batch check with 50 duplicate requests took: {:?}",
-        duration
-    );
+    println!("Batch check with 50 duplicate requests took: {duration:?}");
 
     Ok(())
 }

--- a/crates/compatibility-tests/tests/test_section_13_check_performance.rs
+++ b/crates/compatibility-tests/tests/test_section_13_check_performance.rs
@@ -51,16 +51,12 @@ async fn test_check_latency_direct_relation() -> Result<()> {
     let avg_latency = total_duration / iterations;
 
     // Assert: Performance baseline documented
-    println!(
-        "OpenFGA direct relation check average latency: {:?}",
-        avg_latency
-    );
+    println!("OpenFGA direct relation check average latency: {avg_latency:?}");
 
     // Sanity check: Should complete in reasonable time (< 1 second per check)
     assert!(
         avg_latency.as_millis() < 1000,
-        "Direct relation check should complete in < 1s, got: {:?}",
-        avg_latency
+        "Direct relation check should complete in < 1s, got: {avg_latency:?}"
     );
 
     Ok(())
@@ -174,15 +170,11 @@ async fn test_check_latency_computed_union() -> Result<()> {
     let avg_latency = total_duration / iterations;
 
     // Assert: Performance baseline documented
-    println!(
-        "OpenFGA union relation check average latency: {:?}",
-        avg_latency
-    );
+    println!("OpenFGA union relation check average latency: {avg_latency:?}");
 
     assert!(
         avg_latency.as_millis() < 1000,
-        "Union relation check should complete in < 1s, got: {:?}",
-        avg_latency
+        "Union relation check should complete in < 1s, got: {avg_latency:?}"
     );
 
     Ok(())
@@ -307,15 +299,11 @@ async fn test_check_latency_deep_nested() -> Result<()> {
     let avg_latency = total_duration / iterations;
 
     // Assert: Performance baseline documented
-    println!(
-        "OpenFGA deep nested (5-hop) check average latency: {:?}",
-        avg_latency
-    );
+    println!("OpenFGA deep nested (5-hop) check average latency: {avg_latency:?}");
 
     assert!(
         avg_latency.as_millis() < 2000,
-        "Deep nested check should complete in < 2s, got: {:?}",
-        avg_latency
+        "Deep nested check should complete in < 2s, got: {avg_latency:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_15_listobjects_api.rs
+++ b/crates/compatibility-tests/tests/test_section_15_listobjects_api.rs
@@ -346,8 +346,7 @@ async fn test_listobjects_with_type_filter() -> Result<()> {
     for object_id in &object_ids {
         assert!(
             object_id.starts_with("document:"),
-            "All results should be documents, got: {}",
-            object_id
+            "All results should be documents, got: {object_id}"
         );
     }
 

--- a/crates/compatibility-tests/tests/test_section_16_edge_cases.rs
+++ b/crates/compatibility-tests/tests/test_section_16_edge_cases.rs
@@ -63,7 +63,7 @@ async fn test_expand_with_deep_relation_tree() -> Result<()> {
     let mut tuples = Vec::new();
     for i in 1..20 {
         tuples.push((
-            format!("folder:level{}", i),
+            format!("folder:level{i}"),
             "parent".to_string(),
             format!("folder:level{}", i + 1),
         ));
@@ -261,7 +261,7 @@ async fn test_listobjects_with_large_result_set() -> Result<()> {
                 (
                     "user:charlie".to_string(),
                     "viewer".to_string(),
-                    format!("document:doc{}", i),
+                    format!("document:doc{i}"),
                 )
             })
             .collect();
@@ -320,8 +320,7 @@ async fn test_listobjects_with_large_result_set() -> Result<()> {
     // Performance check: Should complete in reasonable time (sanity check, not strict benchmark)
     assert!(
         duration.as_secs() < 2,
-        "ListObjects with 1000 results should complete in < 2s, got: {:?}",
-        duration
+        "ListObjects with 1000 results should complete in < 2s, got: {duration:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_18_rate_limiting.rs
+++ b/crates/compatibility-tests/tests/test_section_18_rate_limiting.rs
@@ -42,7 +42,7 @@ async fn test_api_rate_limiting_behavior() -> Result<()> {
         match response.status().as_u16() {
             200 => success_count += 1,
             429 => rate_limited_count += 1,
-            status => panic!("Unexpected status code: {}", status),
+            status => panic!("Unexpected status code: {status}"),
         }
     }
 
@@ -100,8 +100,7 @@ async fn test_rate_limit_headers() -> Result<()> {
     for header in &rate_limit_headers {
         assert!(
             headers.get(*header).is_none(),
-            "OpenFGA should not return {} header (no built-in rate limiting)",
-            header
+            "OpenFGA should not return {header} header (no built-in rate limiting)"
         );
     }
 

--- a/crates/compatibility-tests/tests/test_section_19_consistency.rs
+++ b/crates/compatibility-tests/tests/test_section_19_consistency.rs
@@ -108,7 +108,7 @@ async fn test_concurrent_writes_to_same_tuple() -> Result<()> {
                             // Expected: transactional conflict
                             conflict_count += 1;
                             let body = resp.text().await.unwrap_or_default();
-                            eprintln!("Request {} returned 409 Conflict: {}", i, body);
+                            eprintln!("Request {i} returned 409 Conflict: {body}");
                         }
                         400 => {
                             // Expected: tuple already exists - verify error code
@@ -122,35 +122,34 @@ async fn test_concurrent_writes_to_same_tuple() -> Result<()> {
                                         == Some("cannot_allow_duplicate_tuples_in_one_request")
                                 {
                                     duplicate_count += 1;
-                                    eprintln!("Request {} returned 400 (duplicate): {}", i, body);
+                                    eprintln!("Request {i} returned 400 (duplicate): {body}");
                                 } else {
                                     // 400 for unexpected reason - count as other error
                                     other_error_count += 1;
                                     eprintln!(
-                                        "Request {} returned 400 with unexpected code {:?}: {}",
-                                        i, error_code, body
+                                        "Request {i} returned 400 with unexpected code {error_code:?}: {body}"
                                     );
                                 }
                             } else {
                                 // Couldn't parse error body - count as other error
                                 other_error_count += 1;
-                                eprintln!("Request {} returned 400 (unparseable): {}", i, body);
+                                eprintln!("Request {i} returned 400 (unparseable): {body}");
                             }
                         }
                         _ => {
                             other_error_count += 1;
                             let body = resp.text().await.unwrap_or_default();
-                            eprintln!("Request {} returned {}: {}", i, status, body);
+                            eprintln!("Request {i} returned {status}: {body}");
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("Request {} failed: {}", i, e);
+                    eprintln!("Request {i} failed: {e}");
                     other_error_count += 1;
                 }
             },
             Err(e) => {
-                eprintln!("Task join error: {}", e);
+                eprintln!("Task join error: {e}");
                 other_error_count += 1;
             }
         }
@@ -159,8 +158,7 @@ async fn test_concurrent_writes_to_same_tuple() -> Result<()> {
     // Key assertion: At least one write should succeed
     assert!(
         success_count >= 1,
-        "At least one concurrent write should succeed (got {})",
-        success_count
+        "At least one concurrent write should succeed (got {success_count})"
     );
 
     // Expected errors are 409 Conflict or 400 duplicate tuple
@@ -236,8 +234,8 @@ async fn test_read_after_write_consistency() -> Result<()> {
 
     // Perform 20 write-then-read cycles to verify consistency
     for i in 0..20 {
-        let user = format!("user:test{}", i);
-        let object = format!("document:doc{}", i);
+        let user = format!("user:test{i}");
+        let object = format!("document:doc{i}");
 
         // Write tuple
         let write_request = json!({
@@ -258,8 +256,7 @@ async fn test_read_after_write_consistency() -> Result<()> {
 
         assert!(
             write_response.status().is_success(),
-            "Write {} should succeed",
-            i
+            "Write {i} should succeed"
         );
 
         // Immediately read - should see the new tuple
@@ -288,8 +285,7 @@ async fn test_read_after_write_consistency() -> Result<()> {
         assert_eq!(
             tuples.len(),
             1,
-            "Iteration {}: Read immediately after write should return the tuple",
-            i
+            "Iteration {i}: Read immediately after write should return the tuple"
         );
     }
 
@@ -507,7 +503,7 @@ async fn test_check_with_stale_model_id() -> Result<()> {
         });
 
         let _new_model_id = create_authorization_model(&store_id, model).await?;
-        eprintln!("Created model version {}", i);
+        eprintln!("Created model version {i}");
     }
 
     let client = reqwest::Client::new();

--- a/crates/compatibility-tests/tests/test_section_2.rs
+++ b/crates/compatibility-tests/tests/test_section_2.rs
@@ -13,20 +13,17 @@ fn test_can_generate_valid_user_identifiers() -> Result<()> {
         // Assert: Verify format is correct (user:<id>)
         assert!(
             user_identifier.starts_with("user:"),
-            "User identifier should start with 'user:', got: {}",
-            user_identifier
+            "User identifier should start with 'user:', got: {user_identifier}"
         );
         assert!(
             user_identifier.contains(user_id),
-            "User identifier should contain the user ID, got: {}",
-            user_identifier
+            "User identifier should contain the user ID, got: {user_identifier}"
         );
 
         // Verify it's a valid format for OpenFGA
         assert!(
             is_valid_user_format(&user_identifier),
-            "User identifier should be valid: {}",
-            user_identifier
+            "User identifier should be valid: {user_identifier}"
         );
     }
 
@@ -60,7 +57,7 @@ fn test_can_generate_valid_user_identifiers() -> Result<()> {
 
 /// Generate a user identifier in OpenFGA format
 fn generate_user_identifier(user_id: &str) -> String {
-    format!("user:{}", user_id)
+    format!("user:{user_id}")
 }
 
 /// Check if a string is a valid user identifier format
@@ -113,8 +110,7 @@ fn test_can_generate_valid_object_identifiers() -> Result<()> {
         // Assert: Verify format is correct (type:id)
         assert!(
             object_identifier.contains(':'),
-            "Object identifier should contain ':', got: {}",
-            object_identifier
+            "Object identifier should contain ':', got: {object_identifier}"
         );
 
         let parts: Vec<&str> = object_identifier.split(':').collect();
@@ -138,8 +134,7 @@ fn test_can_generate_valid_object_identifiers() -> Result<()> {
         // Verify it's a valid format for OpenFGA
         assert!(
             is_valid_object_format(&object_identifier),
-            "Object identifier should be valid: {}",
-            object_identifier
+            "Object identifier should be valid: {object_identifier}"
         );
     }
 
@@ -170,7 +165,7 @@ fn test_can_generate_valid_object_identifiers() -> Result<()> {
 
 /// Generate an object identifier in OpenFGA format
 fn generate_object_identifier(object_type: &str, object_id: &str) -> String {
-    format!("{}:{}", object_type, object_id)
+    format!("{object_type}:{object_id}")
 }
 
 /// Check if a string is a valid object identifier format
@@ -234,8 +229,7 @@ fn test_can_generate_valid_relation_names() -> Result<()> {
     for relation_name in relation_names {
         assert!(
             is_valid_relation_name(relation_name),
-            "Relation name should be valid: {}",
-            relation_name
+            "Relation name should be valid: {relation_name}"
         );
     }
 
@@ -387,13 +381,11 @@ fn test_can_generate_authorization_models_with_direct_relations() -> Result<()> 
     for (relation_name, relation_def) in &document_type.relations {
         assert!(
             relation_def.is_direct,
-            "Relation '{}' should be direct",
-            relation_name
+            "Relation '{relation_name}' should be direct"
         );
         assert!(
             relation_def.allowed_types.contains(&"user".to_string()),
-            "Relation '{}' should allow 'user' type",
-            relation_name
+            "Relation '{relation_name}' should allow 'user' type"
         );
     }
 

--- a/crates/compatibility-tests/tests/test_section_20_limits.rs
+++ b/crates/compatibility-tests/tests/test_section_20_limits.rs
@@ -463,7 +463,7 @@ async fn test_maximum_relation_depth() -> Result<()> {
     let mut tuples = Vec::new();
     for i in 1..24 {
         tuples.push((
-            format!("folder:level{}", i),
+            format!("folder:level{i}"),
             "parent".to_string(),
             format!("folder:level{}", i + 1),
         ));
@@ -575,8 +575,7 @@ async fn test_request_timeout_behavior() -> Result<()> {
     );
     assert!(
         duration.as_secs() < 5,
-        "Simple check should complete in < 5s (took {:?})",
-        duration
+        "Simple check should complete in < 5s (took {duration:?})"
     );
 
     // Document: OpenFGA server-side timeouts are configured via:

--- a/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
+++ b/crates/compatibility-tests/tests/test_section_21_grpc_setup.rs
@@ -19,8 +19,7 @@ async fn test_can_connect_to_openfga_grpc_service() -> Result<()> {
         services
             .iter()
             .any(|s| s.contains("openfga.v1.OpenFGAService")),
-        "OpenFGA gRPC service should be available. Found: {:?}",
-        services
+        "OpenFGA gRPC service should be available. Found: {services:?}"
     );
 
     // Also verify health service is available
@@ -389,8 +388,7 @@ async fn test_can_call_check_service_methods() -> Result<()> {
 
     assert!(
         !allowed,
-        "Check should return allowed: false for non-existent tuple, got: {:?}",
-        check_response2
+        "Check should return allowed: false for non-existent tuple, got: {check_response2:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
+++ b/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
@@ -27,7 +27,7 @@ async fn rest_call(
             "GET" => client.get(&url),
             "POST" => client.post(&url),
             "DELETE" => client.delete(&url),
-            _ => anyhow::bail!("Unsupported method: {}", method),
+            _ => anyhow::bail!("Unsupported method: {method}"),
         };
         if let Some(json_data) = data {
             builder = builder.json(json_data);
@@ -39,7 +39,7 @@ async fn rest_call(
     if !response.status().is_success() {
         let status = response.status();
         let text = response.text().await.unwrap_or_default();
-        anyhow::bail!("REST call failed with status {}: {}", status, text);
+        anyhow::bail!("REST call failed with status {status}: {text}");
     }
 
     let text = response.text().await?;
@@ -122,7 +122,7 @@ async fn test_grpc_store_get_matches_rest() -> Result<()> {
     )?;
 
     // Get via REST
-    let rest_response = rest_call(&client, "GET", &format!("/stores/{}", store_id), None).await?;
+    let rest_response = rest_call(&client, "GET", &format!("/stores/{store_id}"), None).await?;
 
     // Assert: Both should return same data
     assert_eq!(
@@ -168,13 +168,8 @@ async fn test_grpc_store_delete_matches_rest() -> Result<()> {
     )?;
 
     // Delete via REST
-    let rest_delete = rest_call(
-        &client,
-        "DELETE",
-        &format!("/stores/{}", rest_store_id),
-        None,
-    )
-    .await?;
+    let rest_delete =
+        rest_call(&client, "DELETE", &format!("/stores/{rest_store_id}"), None).await?;
 
     // Assert: Both should return empty object
     assert!(grpc_delete.is_object(), "gRPC delete should return object");
@@ -218,7 +213,7 @@ async fn test_grpc_check_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -237,7 +232,7 @@ async fn test_grpc_check_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&write_data),
     )
     .await?;
@@ -259,7 +254,7 @@ async fn test_grpc_check_matches_rest() -> Result<()> {
     let rest_check = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         Some(&json!({
             "tuple_key": {
                 "user": "user:parity-user",
@@ -319,7 +314,7 @@ async fn test_grpc_batch_check_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -338,7 +333,7 @@ async fn test_grpc_batch_check_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&write_data),
     )
     .await?;
@@ -373,7 +368,7 @@ async fn test_grpc_batch_check_matches_rest() -> Result<()> {
     let rest_batch = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/batch-check", store_id),
+        &format!("/stores/{store_id}/batch-check"),
         Some(&json!({
             "checks": [
                 {
@@ -503,7 +498,7 @@ async fn test_grpc_write_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -527,7 +522,7 @@ async fn test_grpc_write_matches_rest() -> Result<()> {
     let rest_write = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&json!({
             "writes": {
                 "tuple_keys": [{
@@ -616,7 +611,7 @@ async fn test_grpc_read_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -625,7 +620,7 @@ async fn test_grpc_read_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&json!({
             "writes": {
                 "tuple_keys": [{
@@ -655,7 +650,7 @@ async fn test_grpc_read_matches_rest() -> Result<()> {
     let rest_read = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/read", store_id),
+        &format!("/stores/{store_id}/read"),
         Some(&json!({
             "tuple_key": {
                 "user": "user:reader",
@@ -724,7 +719,7 @@ async fn test_grpc_expand_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -733,7 +728,7 @@ async fn test_grpc_expand_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&json!({
             "writes": {
                 "tuple_keys": [{
@@ -762,7 +757,7 @@ async fn test_grpc_expand_matches_rest() -> Result<()> {
     let rest_expand = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/expand", store_id),
+        &format!("/stores/{store_id}/expand"),
         Some(&json!({
             "tuple_key": {
                 "relation": "viewer",
@@ -829,7 +824,7 @@ async fn test_grpc_listobjects_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/authorization-models", store_id),
+        &format!("/stores/{store_id}/authorization-models"),
         Some(&model),
     )
     .await?;
@@ -838,7 +833,7 @@ async fn test_grpc_listobjects_matches_rest() -> Result<()> {
     rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         Some(&json!({
             "writes": {
                 "tuple_keys": [
@@ -866,7 +861,7 @@ async fn test_grpc_listobjects_matches_rest() -> Result<()> {
     let rest_list = rest_call(
         &client,
         "POST",
-        &format!("/stores/{}/list-objects", store_id),
+        &format!("/stores/{store_id}/list-objects"),
         Some(&json!({
             "type": "document",
             "relation": "viewer",

--- a/crates/compatibility-tests/tests/test_section_23_grpc_features.rs
+++ b/crates/compatibility-tests/tests/test_section_23_grpc_features.rs
@@ -235,8 +235,7 @@ async fn test_grpc_error_codes_match_http() -> Result<()> {
     assert!(!success, "gRPC should fail for invalid store ID");
     assert!(
         stderr.contains("InvalidArgument"),
-        "gRPC error should be InvalidArgument: {}",
-        stderr
+        "gRPC error should be InvalidArgument: {stderr}"
     );
 
     // HTTP call - URL-encode the path segment to handle `#` correctly
@@ -272,8 +271,7 @@ async fn test_grpc_error_codes_match_http() -> Result<()> {
             || stderr.contains("NotFound")
             || stderr.contains("Code(")
             || stderr.contains("store"),
-        "gRPC error should indicate store not found: {}",
-        stderr
+        "gRPC error should indicate store not found: {stderr}"
     );
 
     // HTTP equivalent
@@ -301,8 +299,7 @@ async fn test_grpc_error_codes_match_http() -> Result<()> {
     assert!(!success, "gRPC should fail for missing required field");
     assert!(
         stderr.contains("InvalidArgument"),
-        "gRPC error should be InvalidArgument for validation: {}",
-        stderr
+        "gRPC error should be InvalidArgument for validation: {stderr}"
     );
 
     Ok(())
@@ -335,15 +332,13 @@ async fn test_grpc_error_details_format() -> Result<()> {
 
     assert!(
         stderr.contains("Code:") || stderr.contains("code"),
-        "Error should contain error code: {}",
-        stderr
+        "Error should contain error code: {stderr}"
     );
     assert!(
         stderr.contains("Message:")
             || stderr.contains("message")
             || stderr.contains("type_definitions"),
-        "Error should contain message or description: {}",
-        stderr
+        "Error should contain message or description: {stderr}"
     );
 
     // Test 2: Check that successful responses don't contain error fields
@@ -383,8 +378,7 @@ async fn test_grpc_error_details_format() -> Result<()> {
         error_lower.contains("user")
             || error_lower.contains("empty")
             || error_lower.contains("required"),
-        "Error message should indicate the specific validation issue: {}",
-        stderr
+        "Error message should indicate the specific validation issue: {stderr}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_25_tuple_conditions.rs
+++ b/crates/compatibility-tests/tests/test_section_25_tuple_conditions.rs
@@ -284,8 +284,7 @@ async fn test_writing_tuple_with_mismatched_context_types_returns_400() -> Resul
     let status = response.status();
     assert!(
         status == StatusCode::BAD_REQUEST || status.is_success(),
-        "Writing tuple with mismatched context type should return 400 or succeed (with validation at check time), got: {}",
-        status
+        "Writing tuple with mismatched context type should return 400 or succeed (with validation at check time), got: {status}"
     );
 
     Ok(())
@@ -426,8 +425,7 @@ async fn test_can_delete_tuple_with_condition() -> Result<()> {
 
     assert!(
         tuples.is_empty(),
-        "Tuple should be deleted, but found: {:?}",
-        tuples
+        "Tuple should be deleted, but found: {tuples:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_26_read_conditions.rs
+++ b/crates/compatibility-tests/tests/test_section_26_read_conditions.rs
@@ -118,8 +118,7 @@ async fn test_read_returns_tuple_with_condition_name() -> Result<()> {
 
     assert!(
         condition.is_object(),
-        "Tuple should include condition, got: {:?}",
-        tuple
+        "Tuple should include condition, got: {tuple:?}"
     );
     assert_eq!(
         condition["name"].as_str(),
@@ -196,8 +195,7 @@ async fn test_read_returns_tuple_with_condition_context() -> Result<()> {
     let context = &condition["context"];
     assert!(
         context.is_object() || condition["name"].is_string(),
-        "Condition context should be returned, got: {:?}",
-        condition
+        "Condition context should be returned, got: {condition:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_27_check_conditions.rs
+++ b/crates/compatibility-tests/tests/test_section_27_check_conditions.rs
@@ -372,9 +372,7 @@ async fn test_check_without_required_context_returns_error() -> Result<()> {
     // OpenFGA may return 400 error OR return allowed: false when context is missing
     assert!(
         status == StatusCode::BAD_REQUEST || body["allowed"].as_bool() == Some(false),
-        "Check without required context should return error or false, got status: {}, body: {:?}",
-        status,
-        body
+        "Check without required context should return error or false, got status: {status}, body: {body:?}"
     );
 
     Ok(())
@@ -434,9 +432,7 @@ async fn test_check_with_partial_context_returns_error() -> Result<()> {
     // Document actual behavior - may error or return false for missing params
     assert!(
         status == StatusCode::BAD_REQUEST || body["allowed"].as_bool() == Some(false),
-        "Check with partial context should return error or false, got status: {}, body: {:?}",
-        status,
-        body
+        "Check with partial context should return error or false, got status: {status}, body: {body:?}"
     );
 
     Ok(())
@@ -496,9 +492,7 @@ async fn test_check_with_wrong_context_type_returns_error() -> Result<()> {
     // Document actual behavior - invalid type should cause error or false
     assert!(
         status == StatusCode::BAD_REQUEST || body["allowed"].as_bool() == Some(false),
-        "Check with wrong context type should return error or false, got status: {}, body: {:?}",
-        status,
-        body
+        "Check with wrong context type should return error or false, got status: {status}, body: {body:?}"
     );
 
     Ok(())
@@ -1002,8 +996,7 @@ async fn test_contextual_tuples_with_conditions() -> Result<()> {
         // Document if not supported
         assert!(
             status == StatusCode::BAD_REQUEST,
-            "If not supported, should return 400, got: {}",
-            status
+            "If not supported, should return 400, got: {status}"
         );
     }
 

--- a/crates/compatibility-tests/tests/test_section_28_cel_edge_cases.rs
+++ b/crates/compatibility-tests/tests/test_section_28_cel_edge_cases.rs
@@ -201,9 +201,7 @@ async fn test_null_values_in_context() -> Result<()> {
     // Null should either cause error, return false, or be handled gracefully
     assert!(
         status.is_success() || status.as_u16() == 400,
-        "Null value in context should be handled, got status: {}, body: {:?}",
-        status,
-        body
+        "Null value in context should be handled, got status: {status}, body: {body:?}"
     );
 
     Ok(())
@@ -303,8 +301,7 @@ async fn test_very_long_string_values_in_context() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.as_u16() == 400,
-        "Very long string should be handled gracefully, got: {}",
-        status
+        "Very long string should be handled gracefully, got: {status}"
     );
 
     Ok(())
@@ -386,7 +383,7 @@ async fn test_large_list_values_in_context() -> Result<()> {
         .await?;
 
     // Create large list (1000 items)
-    let large_list: Vec<String> = (0..1000).map(|i| format!("item-{}", i)).collect();
+    let large_list: Vec<String> = (0..1000).map(|i| format!("item-{i}")).collect();
     // Add target to the list
     let mut items = large_list;
     items.push("target".to_string());
@@ -411,8 +408,7 @@ async fn test_large_list_values_in_context() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.as_u16() == 400,
-        "Large list should be handled gracefully, got: {}",
-        status
+        "Large list should be handled gracefully, got: {status}"
     );
 
     if status.is_success() {
@@ -533,8 +529,7 @@ async fn test_deeply_nested_map_values_in_context() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.as_u16() == 400,
-        "Nested map should be handled, got: {}",
-        status
+        "Nested map should be handled, got: {status}"
     );
 
     Ok(())
@@ -641,15 +636,13 @@ async fn test_cel_expression_timeout_behavior() -> Result<()> {
     // CEL should complete quickly (within reasonable time)
     assert!(
         elapsed.as_secs() < 5,
-        "CEL expression should complete quickly, took: {:?}",
-        elapsed
+        "CEL expression should complete quickly, took: {elapsed:?}"
     );
 
     let status = response.status();
     assert!(
         status.is_success(),
-        "Complex CEL expression should succeed, got: {}",
-        status
+        "Complex CEL expression should succeed, got: {status}"
     );
 
     Ok(())
@@ -750,9 +743,7 @@ async fn test_cel_expression_undefined_variable() -> Result<()> {
     // Undefined variable should cause error or return false
     assert!(
         status.as_u16() == 400 || body["allowed"].as_bool() == Some(false),
-        "Undefined variable access should error or return false, got status: {}, body: {:?}",
-        status,
-        body
+        "Undefined variable access should error or return false, got status: {status}, body: {body:?}"
     );
 
     Ok(())
@@ -859,9 +850,7 @@ async fn test_cel_expression_division_by_zero() -> Result<()> {
         status.as_u16() == 400
             || status.as_u16() == 500
             || body["allowed"].as_bool() == Some(false),
-        "Division by zero should be handled gracefully, got status: {}, body: {:?}",
-        status,
-        body
+        "Division by zero should be handled gracefully, got status: {status}, body: {body:?}"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_29_condition_performance.rs
+++ b/crates/compatibility-tests/tests/test_section_29_condition_performance.rs
@@ -162,18 +162,17 @@ async fn test_measure_check_latency_simple_condition() -> Result<()> {
     let p99 = latencies[(iterations as f64 * 0.99) as usize];
 
     println!("\n=== Simple Condition Check Latency ===");
-    println!("Iterations: {}", iterations);
-    println!("Average: {:.0}µs", avg);
-    println!("P50: {:.0}µs", p50);
-    println!("P95: {:.0}µs", p95);
-    println!("P99: {:.0}µs", p99);
+    println!("Iterations: {iterations}");
+    println!("Average: {avg:.0}µs");
+    println!("P50: {p50:.0}µs");
+    println!("P95: {p95:.0}µs");
+    println!("P99: {p99:.0}µs");
     println!("======================================\n");
 
     // Baseline assertion - should be reasonably fast
     assert!(
         avg < 100_000.0, // 100ms average as upper bound
-        "Simple condition check should be fast, got avg: {:.0}µs",
-        avg
+        "Simple condition check should be fast, got avg: {avg:.0}µs"
     );
 
     Ok(())
@@ -302,18 +301,17 @@ async fn test_measure_check_latency_complex_condition() -> Result<()> {
     let p99 = latencies[(iterations as f64 * 0.99) as usize];
 
     println!("\n=== Complex Condition Check Latency ===");
-    println!("Iterations: {}", iterations);
-    println!("Average: {:.0}µs", avg);
-    println!("P50: {:.0}µs", p50);
-    println!("P95: {:.0}µs", p95);
-    println!("P99: {:.0}µs", p99);
+    println!("Iterations: {iterations}");
+    println!("Average: {avg:.0}µs");
+    println!("P50: {p50:.0}µs");
+    println!("P95: {p95:.0}µs");
+    println!("P99: {p99:.0}µs");
     println!("=======================================\n");
 
     // Baseline assertion
     assert!(
         avg < 100_000.0,
-        "Complex condition check should be reasonably fast, got avg: {:.0}µs",
-        avg
+        "Complex condition check should be reasonably fast, got avg: {avg:.0}µs"
     );
 
     Ok(())
@@ -327,7 +325,7 @@ async fn test_measure_batch_check_with_conditions() -> Result<()> {
     let client = shared_client();
 
     // Write multiple tuples with conditions
-    let users: Vec<String> = (0..10).map(|i| format!("user:batch-user-{}", i)).collect();
+    let users: Vec<String> = (0..10).map(|i| format!("user:batch-user-{i}")).collect();
     let tuple_keys: Vec<serde_json::Value> = users
         .iter()
         .map(|user| {
@@ -417,18 +415,17 @@ async fn test_measure_batch_check_with_conditions() -> Result<()> {
     let avg_per_check = avg / checks_per_batch as f64;
 
     println!("\n=== Batch Check with Conditions Latency ===");
-    println!("Batch size: {} checks", checks_per_batch);
-    println!("Iterations: {}", iterations);
-    println!("Average (total): {:.0}µs", avg);
-    println!("Average (per check): {:.0}µs", avg_per_check);
-    println!("P50 (total): {:.0}µs", p50);
+    println!("Batch size: {checks_per_batch} checks");
+    println!("Iterations: {iterations}");
+    println!("Average (total): {avg:.0}µs");
+    println!("Average (per check): {avg_per_check:.0}µs");
+    println!("P50 (total): {p50:.0}µs");
     println!("===========================================\n");
 
     // Baseline assertion
     assert!(
         avg < 500_000.0, // 500ms for batch of 10
-        "Batch check with conditions should be reasonably fast, got avg: {:.0}µs",
-        avg
+        "Batch check with conditions should be reasonably fast, got avg: {avg:.0}µs"
     );
 
     Ok(())
@@ -544,18 +541,17 @@ async fn test_compare_conditional_vs_non_conditional_latency() -> Result<()> {
     let overhead = ((cond_avg - non_cond_avg) / non_cond_avg * 100.0).max(0.0);
 
     println!("\n=== Conditional vs Non-Conditional Check Comparison ===");
-    println!("Iterations: {}", iterations);
-    println!("Non-conditional average: {:.0}µs", non_cond_avg);
-    println!("Conditional average: {:.0}µs", cond_avg);
-    println!("Condition overhead: {:.1}%", overhead);
+    println!("Iterations: {iterations}");
+    println!("Non-conditional average: {non_cond_avg:.0}µs");
+    println!("Conditional average: {cond_avg:.0}µs");
+    println!("Condition overhead: {overhead:.1}%");
     println!("======================================================\n");
 
     // Document the overhead - CEL evaluation adds some latency
     // This is expected and acceptable for the flexibility it provides
     assert!(
         cond_avg < 100_000.0,
-        "Conditional check should still be fast, got avg: {:.0}µs",
-        cond_avg
+        "Conditional check should still be fast, got avg: {cond_avg:.0}µs"
     );
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_30_listusers_api.rs
+++ b/crates/compatibility-tests/tests/test_section_30_listusers_api.rs
@@ -86,24 +86,18 @@ fn validate_listusers_response(response_body: &serde_json::Value) -> &Vec<serde_
 
         assert!(
             has_object || has_userset || has_wildcard,
-            "User at index {} must have 'object', 'userset', or 'wildcard' field. Got: {}",
-            i,
-            user
+            "User at index {i} must have 'object', 'userset', or 'wildcard' field. Got: {user}"
         );
 
         // Validate object format if present
         if let Some(object) = user.get("object") {
             assert!(
                 object.get("type").and_then(|t| t.as_str()).is_some(),
-                "User at index {} 'object' field missing 'type'. Got: {}",
-                i,
-                object
+                "User at index {i} 'object' field missing 'type'. Got: {object}"
             );
             assert!(
                 object.get("id").and_then(|id| id.as_str()).is_some(),
-                "User at index {} 'object' field missing 'id'. Got: {}",
-                i,
-                object
+                "User at index {i} 'object' field missing 'id'. Got: {object}"
             );
         }
 
@@ -111,21 +105,15 @@ fn validate_listusers_response(response_body: &serde_json::Value) -> &Vec<serde_
         if let Some(userset) = user.get("userset") {
             assert!(
                 userset.get("type").and_then(|t| t.as_str()).is_some(),
-                "User at index {} 'userset' field missing 'type'. Got: {}",
-                i,
-                userset
+                "User at index {i} 'userset' field missing 'type'. Got: {userset}"
             );
             assert!(
                 userset.get("id").and_then(|id| id.as_str()).is_some(),
-                "User at index {} 'userset' field missing 'id'. Got: {}",
-                i,
-                userset
+                "User at index {i} 'userset' field missing 'id'. Got: {userset}"
             );
             assert!(
                 userset.get("relation").and_then(|r| r.as_str()).is_some(),
-                "User at index {} 'userset' field missing 'relation'. Got: {}",
-                i,
-                userset
+                "User at index {i} 'userset' field missing 'relation'. Got: {userset}"
             );
         }
 
@@ -133,9 +121,7 @@ fn validate_listusers_response(response_body: &serde_json::Value) -> &Vec<serde_
         if let Some(wildcard) = user.get("wildcard") {
             assert!(
                 wildcard.get("type").and_then(|t| t.as_str()).is_some(),
-                "User at index {} 'wildcard' field missing 'type'. Got: {}",
-                i,
-                wildcard
+                "User at index {i} 'wildcard' field missing 'type'. Got: {wildcard}"
             );
         }
     }
@@ -227,7 +213,7 @@ async fn test_listusers_returns_users_with_direct_relation() -> Result<()> {
             u.get("object").and_then(|o| {
                 let user_type = o.get("type")?.as_str()?;
                 let user_id = o.get("id")?.as_str()?;
-                Some(format!("{}:{}", user_type, user_id))
+                Some(format!("{user_type}:{user_id}"))
             })
         })
         .collect();
@@ -502,7 +488,7 @@ async fn test_listusers_with_contextual_tuples() -> Result<()> {
             u.get("object").and_then(|o| {
                 let user_type = o.get("type")?.as_str()?;
                 let user_id = o.get("id")?.as_str()?;
-                Some(format!("{}:{}", user_type, user_id))
+                Some(format!("{user_type}:{user_id}"))
             })
         })
         .collect();
@@ -603,7 +589,7 @@ async fn test_listusers_with_computed_relations() -> Result<()> {
             u.get("object").and_then(|o| {
                 let user_type = o.get("type")?.as_str()?;
                 let user_id = o.get("id")?.as_str()?;
-                Some(format!("{}:{}", user_type, user_id))
+                Some(format!("{user_type}:{user_id}"))
             })
         })
         .collect();

--- a/crates/compatibility-tests/tests/test_section_31_readchanges_api.rs
+++ b/crates/compatibility-tests/tests/test_section_31_readchanges_api.rs
@@ -251,8 +251,7 @@ async fn test_readchanges_with_type_filter() -> Result<()> {
 
         assert!(
             obj.starts_with("document:"),
-            "Filtered changes should only include documents, got: {}",
-            obj
+            "Filtered changes should only include documents, got: {obj}"
         );
     }
 
@@ -269,9 +268,9 @@ async fn test_readchanges_pagination_page_size() -> Result<()> {
     let tuples: Vec<_> = (0..10)
         .map(|i| {
             (
-                format!("user:user{}", i),
+                format!("user:user{i}"),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
             )
         })
         .collect();
@@ -335,9 +334,9 @@ async fn test_readchanges_continuation_token() -> Result<()> {
     let tuples: Vec<_> = (0..10)
         .map(|i| {
             (
-                format!("user:user{}", i),
+                format!("user:user{i}"),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
             )
         })
         .collect();
@@ -590,8 +589,7 @@ async fn test_readchanges_type_filter_mismatch_with_token() -> Result<()> {
         status.is_success()
             || status == StatusCode::BAD_REQUEST
             || status == StatusCode::UNPROCESSABLE_ENTITY,
-        "Should either succeed or return validation error, got: {}",
-        status
+        "Should either succeed or return validation error, got: {status}"
     );
 
     Ok(())
@@ -664,9 +662,9 @@ async fn test_readchanges_chronological_order() -> Result<()> {
         write_tuples(
             &store_id,
             vec![(
-                &format!("user:user{}", i),
+                &format!("user:user{i}"),
                 "viewer",
-                &format!("document:doc{}", i),
+                &format!("document:doc{i}"),
             )],
         )
         .await?;

--- a/crates/compatibility-tests/tests/test_section_33_consistency_preference.rs
+++ b/crates/compatibility-tests/tests/test_section_33_consistency_preference.rs
@@ -149,8 +149,7 @@ async fn test_check_with_unspecified_consistency() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.is_client_error(),
-        "UNSPECIFIED consistency should either succeed or return client error, got: {}",
-        status
+        "UNSPECIFIED consistency should either succeed or return client error, got: {status}"
     );
 
     if status.is_success() {
@@ -162,10 +161,7 @@ async fn test_check_with_unspecified_consistency() -> Result<()> {
         );
     } else {
         // Document that UNSPECIFIED is not accepted
-        eprintln!(
-            "INFO: UNSPECIFIED consistency value returned status: {} (acceptable)",
-            status
-        );
+        eprintln!("INFO: UNSPECIFIED consistency value returned status: {status} (acceptable)");
     }
 
     Ok(())
@@ -354,8 +350,7 @@ async fn test_invalid_consistency_value_error() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.is_client_error(),
-        "Invalid consistency value should either be ignored (success) or rejected (client error), got: {}",
-        status
+        "Invalid consistency value should either be ignored (success) or rejected (client error), got: {status}"
     );
 
     if status.is_success() {
@@ -368,10 +363,7 @@ async fn test_invalid_consistency_value_error() -> Result<()> {
             "Response should have 'allowed' field even with invalid consistency"
         );
     } else {
-        eprintln!(
-            "INFO: Invalid consistency value rejected with status: {} (acceptable)",
-            status
-        );
+        eprintln!("INFO: Invalid consistency value rejected with status: {status} (acceptable)");
     }
 
     Ok(())
@@ -418,8 +410,7 @@ async fn test_batchcheck_accepts_consistency_parameter() -> Result<()> {
     let status = response.status();
     assert!(
         status.is_success() || status.is_client_error(),
-        "BatchCheck with consistency should either succeed or return client error, got: {}",
-        status
+        "BatchCheck with consistency should either succeed or return client error, got: {status}"
     );
 
     if status.is_success() {
@@ -428,8 +419,7 @@ async fn test_batchcheck_accepts_consistency_parameter() -> Result<()> {
         assert!(result.is_some(), "BatchCheck should return result");
     } else {
         eprintln!(
-            "INFO: BatchCheck with consistency returned status: {} (may not be supported in this version)",
-            status
+            "INFO: BatchCheck with consistency returned status: {status} (may not be supported in this version)"
         );
     }
 
@@ -476,8 +466,7 @@ async fn test_listusers_accepts_consistency_parameter() -> Result<()> {
 
     assert!(
         status.is_success() || status.is_client_error(),
-        "ListUsers with consistency should either succeed or return client error, got: {}",
-        status
+        "ListUsers with consistency should either succeed or return client error, got: {status}"
     );
 
     if status.is_success() {
@@ -485,10 +474,7 @@ async fn test_listusers_accepts_consistency_parameter() -> Result<()> {
         let users = body.get("users").and_then(|u| u.as_array());
         assert!(users.is_some(), "ListUsers should return users array");
     } else {
-        eprintln!(
-            "INFO: ListUsers with consistency returned status: {}",
-            status
-        );
+        eprintln!("INFO: ListUsers with consistency returned status: {status}");
     }
 
     Ok(())

--- a/crates/compatibility-tests/tests/test_section_34_streamed_listobjects.rs
+++ b/crates/compatibility-tests/tests/test_section_34_streamed_listobjects.rs
@@ -232,7 +232,7 @@ async fn test_streamed_listobjects_large_result_set() -> Result<()> {
             (
                 "user:alice".to_string(),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
             )
         })
         .collect();

--- a/crates/compatibility-tests/tests/test_section_35_modular_models.rs
+++ b/crates/compatibility-tests/tests/test_section_35_modular_models.rs
@@ -60,8 +60,7 @@ async fn is_schema_1_2_supported(store_id: &str) -> bool {
             } else {
                 // 5xx errors or other unexpected status - log warning but treat as unsupported
                 eprintln!(
-                    "WARNING: Unexpected status {} when checking schema 1.2 support. Treating as unsupported.",
-                    status
+                    "WARNING: Unexpected status {status} when checking schema 1.2 support. Treating as unsupported."
                 );
                 false
             }
@@ -69,8 +68,7 @@ async fn is_schema_1_2_supported(store_id: &str) -> bool {
         Err(e) => {
             // Network or other transient errors - log warning
             eprintln!(
-                "WARNING: Network error checking schema 1.2 support: {}. Treating as unsupported.",
-                e
+                "WARNING: Network error checking schema 1.2 support: {e}. Treating as unsupported."
             );
             false
         }

--- a/crates/compatibility-tests/tests/test_section_9_tuple_edge_cases.rs
+++ b/crates/compatibility-tests/tests/test_section_9_tuple_edge_cases.rs
@@ -335,9 +335,7 @@ async fn test_unicode_in_identifiers() -> Result<()> {
         assert_eq!(
             tuples.len(),
             1,
-            "Should read back the Unicode tuple for {}, {}",
-            user,
-            object
+            "Should read back the Unicode tuple for {user}, {object}"
         );
     }
 

--- a/crates/rsfga-api/benches/parse_bench.rs
+++ b/crates/rsfga-api/benches/parse_bench.rs
@@ -239,7 +239,7 @@ fn bench_wide_nested(c: &mut Criterion) {
     for (width, depth) in [(2, 10), (5, 5), (10, 3), (20, 2)] {
         let wide = wide_nested_union(width, depth);
         group.bench_with_input(
-            BenchmarkId::new(format!("{}x{}", width, depth), 1),
+            BenchmarkId::new(format!("{width}x{depth}"), 1),
             &wide,
             |b, input| b.iter(|| parse_userset(black_box(input), "document", "viewer")),
         );

--- a/crates/rsfga-api/src/adapters.rs
+++ b/crates/rsfga-api/src/adapters.rs
@@ -67,8 +67,7 @@ fn parse_child_array(
         .and_then(|v| v.as_array())
         .ok_or_else(|| DomainError::ModelParseError {
             message: format!(
-                "{} requires 'child' array: type '{}', relation '{}'",
-                key, type_name, rel_name
+                "{key} requires 'child' array: type '{type_name}', relation '{rel_name}'"
             ),
         })?;
 
@@ -77,8 +76,7 @@ fn parse_child_array(
     if children.is_empty() {
         return Err(DomainError::ModelParseError {
             message: format!(
-                "{} requires at least one child: type '{}', relation '{}'",
-                key, type_name, rel_name
+                "{key} requires at least one child: type '{type_name}', relation '{rel_name}'"
             ),
         });
     }
@@ -100,8 +98,7 @@ fn parse_userset_inner(
     if depth > MAX_PARSE_DEPTH {
         return Err(DomainError::ModelParseError {
             message: format!(
-                "relation definition exceeds max nesting depth of {}: type '{}', relation '{}'",
-                MAX_PARSE_DEPTH, type_name, rel_name
+                "relation definition exceeds max nesting depth of {MAX_PARSE_DEPTH}: type '{type_name}', relation '{rel_name}'"
             ),
         });
     }
@@ -110,8 +107,7 @@ fn parse_userset_inner(
         .as_object()
         .ok_or_else(|| DomainError::ModelParseError {
             message: format!(
-                "relation definition must be an object: type '{}', relation '{}'",
-                type_name, rel_name
+                "relation definition must be an object: type '{type_name}', relation '{rel_name}'"
             ),
         })?;
 
@@ -128,8 +124,7 @@ fn parse_userset_inner(
         let relation = cu.get("relation").and_then(|v| v.as_str()).ok_or_else(|| {
             DomainError::ModelParseError {
                 message: format!(
-                    "computedUserset requires 'relation' field: type '{}', relation '{}'",
-                    type_name, rel_name
+                    "computedUserset requires 'relation' field: type '{type_name}', relation '{rel_name}'"
                 ),
             }
         })?;
@@ -149,8 +144,7 @@ fn parse_userset_inner(
             .and_then(|v| v.as_str())
             .ok_or_else(|| DomainError::ModelParseError {
                 message: format!(
-                    "tupleToUserset requires 'tupleset.relation' field: type '{}', relation '{}'",
-                    type_name, rel_name
+                    "tupleToUserset requires 'tupleset.relation' field: type '{type_name}', relation '{rel_name}'"
                 ),
             })?;
         let computed_userset = ttu
@@ -160,8 +154,7 @@ fn parse_userset_inner(
             .and_then(|v| v.as_str())
             .ok_or_else(|| DomainError::ModelParseError {
                 message: format!(
-                    "tupleToUserset requires 'computedUserset.relation' field: type '{}', relation '{}'",
-                    type_name, rel_name
+                    "tupleToUserset requires 'computedUserset.relation' field: type '{type_name}', relation '{rel_name}'"
                 ),
             })?;
         return Ok(Userset::TupleToUserset {
@@ -193,16 +186,14 @@ fn parse_userset_inner(
             .get("base")
             .ok_or_else(|| DomainError::ModelParseError {
                 message: format!(
-                    "exclusion requires 'base' field: type '{}', relation '{}'",
-                    type_name, rel_name
+                    "exclusion requires 'base' field: type '{type_name}', relation '{rel_name}'"
                 ),
             })?;
         let subtract = exclusion
             .get("subtract")
             .ok_or_else(|| DomainError::ModelParseError {
                 message: format!(
-                    "exclusion requires 'subtract' field: type '{}', relation '{}'",
-                    type_name, rel_name
+                    "exclusion requires 'subtract' field: type '{type_name}', relation '{rel_name}'"
                 ),
             })?;
         return Ok(Userset::Exclusion {
@@ -220,8 +211,7 @@ fn parse_userset_inner(
     let keys: Vec<_> = obj.keys().collect();
     Err(DomainError::ModelParseError {
         message: format!(
-            "unknown relation definition keys {:?}: type '{}', relation '{}'",
-            keys, type_name, rel_name
+            "unknown relation definition keys {keys:?}: type '{type_name}', relation '{rel_name}'"
         ),
     })
 }
@@ -259,8 +249,7 @@ fn parse_type_constraints(
         let user_type = item.get("type").and_then(|t| t.as_str()).ok_or_else(|| {
             DomainError::ModelParseError {
                 message: format!(
-                    "directly_related_user_types[{}] missing 'type' field: type '{}', relation '{}'",
-                    idx, type_name, rel_name
+                    "directly_related_user_types[{idx}] missing 'type' field: type '{type_name}', relation '{rel_name}'"
                 ),
             }
         })?;
@@ -268,7 +257,7 @@ fn parse_type_constraints(
         let condition = item.get("condition").and_then(|c| c.as_str());
 
         let full_type = if let Some(relation) = item.get("relation").and_then(|r| r.as_str()) {
-            format!("{}#{}", user_type, relation)
+            format!("{user_type}#{relation}")
         } else {
             user_type.to_string()
         };
@@ -320,7 +309,7 @@ impl<S: DataStore> TupleReader for DataStoreTupleReader<S> {
             .read_tuples(store_id, &filter)
             .await
             .map_err(|e| DomainError::ResolverError {
-                message: format!("storage error: {}", e),
+                message: format!("storage error: {e}"),
             })?;
 
         // Convert StoredTuple to StoredTupleRef
@@ -343,7 +332,7 @@ impl<S: DataStore> TupleReader for DataStoreTupleReader<S> {
             Ok(_) => Ok(true),
             Err(rsfga_storage::StorageError::StoreNotFound { .. }) => Ok(false),
             Err(e) => Err(DomainError::ResolverError {
-                message: format!("storage error: {}", e),
+                message: format!("storage error: {e}"),
             }),
         }
     }
@@ -432,13 +421,13 @@ impl<S: DataStore> DataStoreModelReader<S> {
             .get_latest_authorization_model(store_id)
             .await
             .map_err(|e| DomainError::ResolverError {
-                message: format!("storage error: {}", e),
+                message: format!("storage error: {e}"),
             })?;
 
         // Parse the stored model JSON into an AuthorizationModel
         let model_json: serde_json::Value = serde_json::from_str(&stored_model.model_json)
             .map_err(|e| DomainError::ModelParseError {
-                message: format!("failed to parse model JSON: {}", e),
+                message: format!("failed to parse model JSON: {e}"),
             })?;
 
         // Build AuthorizationModel from the parsed JSON
@@ -767,8 +756,7 @@ mod tests {
         // Complex relations should now be parsed correctly
         assert!(
             result.is_ok(),
-            "Failed to parse complex relation: {:?}",
-            result
+            "Failed to parse complex relation: {result:?}"
         );
         let model = result.unwrap();
 
@@ -796,7 +784,7 @@ mod tests {
                     Userset::ComputedUserset { relation } if relation == "editor"
                 ));
             }
-            other => panic!("Expected Union, got {:?}", other),
+            other => panic!("Expected Union, got {other:?}"),
         }
     }
 
@@ -855,7 +843,7 @@ mod tests {
         // Note: moka uses approximate LRU, so we test that the cache doesn't grow unbounded
         for i in 0..10 {
             let model = AuthorizationModel::with_types("1.1", vec![]);
-            reader.cache.insert(format!("store-{}", i), model).await;
+            reader.cache.insert(format!("store-{i}"), model).await;
         }
 
         // Run pending tasks to ensure eviction happens
@@ -1510,7 +1498,7 @@ mod tests {
 
         let reader = DataStoreModelReader::new(storage);
         let result = reader.get_model("test-store").await;
-        assert!(result.is_ok(), "Failed to parse model: {:?}", result);
+        assert!(result.is_ok(), "Failed to parse model: {result:?}");
 
         let model = result.unwrap();
 

--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -117,7 +117,7 @@ impl<S: DataStore> OpenFgaGrpcService<S> {
 fn storage_error_to_status(err: StorageError) -> Status {
     match &err {
         StorageError::StoreNotFound { store_id } => {
-            Status::not_found(format!("store not found: {}", store_id))
+            Status::not_found(format!("store not found: {store_id}"))
         }
         StorageError::TupleNotFound { .. } => Status::not_found(err.to_string()),
         StorageError::InvalidInput { message } => Status::invalid_argument(message),
@@ -134,12 +134,11 @@ fn batch_check_error_to_status(err: rsfga_server::handlers::batch::BatchCheckErr
     use rsfga_server::handlers::batch::BatchCheckError;
     match err {
         BatchCheckError::EmptyBatch => Status::invalid_argument("batch request cannot be empty"),
-        BatchCheckError::BatchTooLarge { size, max } => Status::invalid_argument(format!(
-            "batch size {} exceeds maximum allowed {}",
-            size, max
-        )),
+        BatchCheckError::BatchTooLarge { size, max } => {
+            Status::invalid_argument(format!("batch size {size} exceeds maximum allowed {max}"))
+        }
         BatchCheckError::InvalidCheck { index, message } => {
-            Status::invalid_argument(format!("invalid check at index {}: {}", index, message))
+            Status::invalid_argument(format!("invalid check at index {index}: {message}"))
         }
         BatchCheckError::DomainError(msg) => {
             // Log full error details for debugging - DO NOT expose to clients
@@ -458,16 +457,14 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
         for (index, item) in req.checks.into_iter().enumerate() {
             let tuple_key = item.tuple_key.ok_or_else(|| {
                 Status::invalid_argument(format!(
-                    "tuple_key is required for check at index {}",
-                    index
+                    "tuple_key is required for check at index {index}"
                 ))
             })?;
 
             // Validate correlation_id length to prevent DoS via excessive memory allocation
             if item.correlation_id.len() > MAX_CORRELATION_ID_LENGTH {
                 return Err(Status::invalid_argument(format!(
-                    "correlation_id at index {} exceeds maximum length of {} bytes",
-                    index, MAX_CORRELATION_ID_LENGTH
+                    "correlation_id at index {index} exceeds maximum length of {MAX_CORRELATION_ID_LENGTH} bytes"
                 )));
             }
 

--- a/crates/rsfga-api/src/grpc/tests.rs
+++ b/crates/rsfga-api/src/grpc/tests.rs
@@ -438,14 +438,14 @@ async fn test_batch_check_rpc_rejects_oversized_batch() {
     let checks: Vec<BatchCheckItem> = (0..51)
         .map(|i| BatchCheckItem {
             tuple_key: Some(TupleKey {
-                user: format!("user:user{}", i),
+                user: format!("user:user{i}"),
                 relation: "viewer".to_string(),
-                object: format!("document:doc{}", i),
+                object: format!("document:doc{i}"),
                 condition: None,
             }),
             contextual_tuples: None,
             context: None,
-            correlation_id: format!("check-{}", i),
+            correlation_id: format!("check-{i}"),
         })
         .collect();
 
@@ -483,14 +483,14 @@ async fn test_batch_check_rpc_accepts_max_batch_size() {
     let checks: Vec<BatchCheckItem> = (0..50)
         .map(|i| BatchCheckItem {
             tuple_key: Some(TupleKey {
-                user: format!("user:user{}", i),
+                user: format!("user:user{i}"),
                 relation: "viewer".to_string(),
-                object: format!("document:doc{}", i),
+                object: format!("document:doc{i}"),
                 condition: None,
             }),
             contextual_tuples: None,
             context: None,
-            correlation_id: format!("check-{}", i),
+            correlation_id: format!("check-{i}"),
         })
         .collect();
 
@@ -719,14 +719,14 @@ async fn test_grpc_errors_map_correctly_to_status_codes() {
     for i in 0..100 {
         checks.push(BatchCheckItem {
             tuple_key: Some(TupleKey {
-                user: format!("user:{}", i),
+                user: format!("user:{i}"),
                 relation: "viewer".to_string(),
-                object: format!("doc:{}", i),
+                object: format!("doc:{i}"),
                 condition: None,
             }),
             contextual_tuples: None,
             context: None,
-            correlation_id: format!("check-{}", i),
+            correlation_id: format!("check-{i}"),
         });
     }
 

--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -179,7 +179,7 @@ impl From<StorageError> for ApiError {
     fn from(err: StorageError) -> Self {
         match &err {
             StorageError::StoreNotFound { store_id } => {
-                ApiError::not_found(format!("store not found: {}", store_id))
+                ApiError::not_found(format!("store not found: {store_id}"))
             }
             StorageError::InvalidInput { message } => ApiError::invalid_input(message),
             _ => {
@@ -198,12 +198,11 @@ fn batch_check_error_to_api_error(err: rsfga_server::handlers::batch::BatchCheck
     use rsfga_server::handlers::batch::BatchCheckError;
     match err {
         BatchCheckError::EmptyBatch => ApiError::invalid_input("batch request cannot be empty"),
-        BatchCheckError::BatchTooLarge { size, max } => ApiError::invalid_input(format!(
-            "batch size {} exceeds maximum allowed {}",
-            size, max
-        )),
+        BatchCheckError::BatchTooLarge { size, max } => {
+            ApiError::invalid_input(format!("batch size {size} exceeds maximum allowed {max}"))
+        }
         BatchCheckError::InvalidCheck { index, message } => {
-            ApiError::invalid_input(format!("invalid check at index {}: {}", index, message))
+            ApiError::invalid_input(format!("invalid check at index {index}: {message}"))
         }
         BatchCheckError::DomainError(msg) => {
             // Log full error details for debugging - DO NOT expose to clients
@@ -466,8 +465,7 @@ async fn write_authorization_model<S: DataStore>(
     let model_json_str = model_json.to_string();
     if model_json_str.len() > MAX_AUTHORIZATION_MODEL_SIZE {
         return Err(ApiError::invalid_input(format!(
-            "authorization model exceeds maximum size of {} bytes",
-            MAX_AUTHORIZATION_MODEL_SIZE
+            "authorization model exceeds maximum size of {MAX_AUTHORIZATION_MODEL_SIZE} bytes"
         )));
     }
 
@@ -501,7 +499,7 @@ async fn get_authorization_model<S: DataStore>(
         .await
         .map_err(|e| match e {
             StorageError::ModelNotFound { model_id } => {
-                ApiError::not_found(format!("authorization model not found: {}", model_id))
+                ApiError::not_found(format!("authorization model not found: {model_id}"))
             }
             other => ApiError::from(other),
         })?;

--- a/crates/rsfga-api/src/http/tests.rs
+++ b/crates/rsfga-api/src/http/tests.rs
@@ -365,8 +365,7 @@ async fn test_validation_errors_return_400_with_details() {
     let mut checks = Vec::new();
     for i in 0..100 {
         checks.push(format!(
-            r#"{{"tuple_key": {{"user": "user:{}", "relation": "viewer", "object": "doc:{}"}}, "correlation_id": "check-{}"}}"#,
-            i, i, i
+            r#"{{"tuple_key": {{"user": "user:{i}", "relation": "viewer", "object": "doc:{i}"}}, "correlation_id": "check-{i}"}}"#
         ));
     }
     let body = format!(r#"{{"checks": [{}]}}"#, checks.join(","));
@@ -1144,10 +1143,10 @@ async fn test_list_authorization_models_pagination_works() {
     // Create 3 models
     for i in 0..3 {
         let model = StoredAuthorizationModel::new(
-            format!("model-{}", i),
+            format!("model-{i}"),
             "test-store",
             "1.1",
-            format!(r#"{{"type_definitions": [{{"type": "type{}"}}]}}"#, i),
+            format!(r#"{{"type_definitions": [{{"type": "type{i}"}}]}}"#),
         );
         storage.write_authorization_model(model).await.unwrap();
     }
@@ -1185,8 +1184,7 @@ async fn test_list_authorization_models_pagination_works() {
             Request::builder()
                 .method("GET")
                 .uri(format!(
-                    "/stores/test-store/authorization-models?page_size=2&continuation_token={}",
-                    token
+                    "/stores/test-store/authorization-models?page_size=2&continuation_token={token}"
                 ))
                 .body(Body::empty())
                 .unwrap(),

--- a/crates/rsfga-api/src/utils.rs
+++ b/crates/rsfga-api/src/utils.rs
@@ -54,9 +54,9 @@ pub fn parse_user(user: &str) -> Option<(&str, &str, Option<&str>)> {
 /// - `"team:eng#member"` when `user_relation` is `Some("member")`
 pub fn format_user(user_type: &str, user_id: &str, user_relation: Option<&str>) -> String {
     if let Some(rel) = user_relation {
-        format!("{}:{}#{}", user_type, user_id, rel)
+        format!("{user_type}:{user_id}#{rel}")
     } else {
-        format!("{}:{}", user_type, user_id)
+        format!("{user_type}:{user_id}")
     }
 }
 

--- a/crates/rsfga-api/tests/integration_tests.rs
+++ b/crates/rsfga-api/tests/integration_tests.rs
@@ -47,7 +47,7 @@ async fn test_end_to_end_authorization_flow_works() {
     // Bob is a viewer of document:readme
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": [
@@ -71,7 +71,7 @@ async fn test_end_to_end_authorization_flow_works() {
     // Step 3: Check permissions - Alice should be owner
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:alice",
@@ -87,7 +87,7 @@ async fn test_end_to_end_authorization_flow_works() {
     // Step 4: Check permissions - Bob should be viewer
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:bob",
@@ -103,7 +103,7 @@ async fn test_end_to_end_authorization_flow_works() {
     // Step 5: Check permissions - Bob should NOT be owner
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:bob",
@@ -119,7 +119,7 @@ async fn test_end_to_end_authorization_flow_works() {
     // Step 6: Check permissions - Charlie has no access
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:charlie",
@@ -159,7 +159,7 @@ async fn test_multiple_concurrent_clients_work_correctly() {
     {
         let (status, _) = post_json(
             create_test_app(&storage),
-            &format!("/stores/{}/write", store_id),
+            &format!("/stores/{store_id}/write"),
             serde_json::json!({
                 "writes": {
                     "tuple_keys": [
@@ -185,7 +185,7 @@ async fn test_multiple_concurrent_clients_work_correctly() {
 
                 let (status, response) = post_json(
                     app,
-                    &format!("/stores/{}/check", store_id),
+                    &format!("/stores/{store_id}/check"),
                     serde_json::json!({
                         "tuple_key": {
                             "user": user,
@@ -211,8 +211,8 @@ async fn test_multiple_concurrent_clients_work_correctly() {
 
     // Verify all requests succeeded with correct results
     for (i, status, allowed) in results {
-        assert_eq!(status, StatusCode::OK, "Request {} should succeed", i);
-        assert!(allowed, "Request {} should be allowed", i);
+        assert_eq!(status, StatusCode::OK, "Request {i} should succeed");
+        assert!(allowed, "Request {i} should be allowed");
     }
 }
 
@@ -251,7 +251,7 @@ async fn test_large_authorization_models_work() {
 
         let (status, _) = post_json(
             create_test_app(&storage),
-            &format!("/stores/{}/write", store_id),
+            &format!("/stores/{store_id}/write"),
             serde_json::json!({
                 "writes": {
                     "tuple_keys": tuples
@@ -259,12 +259,7 @@ async fn test_large_authorization_models_work() {
             }),
         )
         .await;
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "Batch {} write should succeed",
-            batch
-        );
+        assert_eq!(status, StatusCode::OK, "Batch {batch} write should succeed");
     }
 
     // Verify we can check permissions for tuples at various positions
@@ -276,7 +271,7 @@ async fn test_large_authorization_models_work() {
     for idx in check_positions {
         let (status, response) = post_json(
             create_test_app(&storage),
-            &format!("/stores/{}/check", store_id),
+            &format!("/stores/{store_id}/check"),
             serde_json::json!({
                 "tuple_key": {
                     "user": format!("user:user{}", idx),
@@ -289,8 +284,7 @@ async fn test_large_authorization_models_work() {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(
             response["allowed"], true,
-            "user{} should have viewer on doc{}",
-            idx, idx
+            "user{idx} should have viewer on doc{idx}"
         );
     }
 
@@ -298,7 +292,7 @@ async fn test_large_authorization_models_work() {
     let last_doc_idx = LARGE_MODEL_TUPLE_COUNT - 1;
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:user0",
@@ -353,7 +347,7 @@ async fn test_deep_hierarchies_work() {
 
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": tuples
@@ -366,7 +360,7 @@ async fn test_deep_hierarchies_work() {
     // Verify Alice is owner of folder0
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/check", store_id),
+        &format!("/stores/{store_id}/check"),
         serde_json::json!({
             "tuple_key": {
                 "user": "user:alice",
@@ -451,7 +445,7 @@ async fn test_batch_check_deduplicates_identical_requests() {
     // Write a single tuple
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": [
@@ -484,7 +478,7 @@ async fn test_batch_check_deduplicates_identical_requests() {
 
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/batch-check", store_id),
+        &format!("/stores/{store_id}/batch-check"),
         serde_json::json!({
             "checks": checks
         }),
@@ -502,11 +496,10 @@ async fn test_batch_check_deduplicates_identical_requests() {
 
     // All should be allowed: true
     for i in 0..10 {
-        let check_result = &result[&format!("dup-check-{}", i)];
+        let check_result = &result[&format!("dup-check-{i}")];
         assert_eq!(
             check_result["allowed"], true,
-            "dup-check-{} should be allowed",
-            i
+            "dup-check-{i} should be allowed"
         );
     }
 }
@@ -547,7 +540,7 @@ async fn test_batch_check_parallel_execution_correctness() {
 
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": write_tuples
@@ -573,7 +566,7 @@ async fn test_batch_check_parallel_execution_correctness() {
 
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/batch-check", store_id),
+        &format!("/stores/{store_id}/batch-check"),
         serde_json::json!({
             "checks": checks
         }),
@@ -586,7 +579,7 @@ async fn test_batch_check_parallel_execution_correctness() {
 
     // Verify correctness: users 0-24 allowed, users 25-49 denied
     for i in 0..50 {
-        let check_result = &result[&format!("parallel-{}", i)];
+        let check_result = &result[&format!("parallel-{i}")];
         let expected = i < 25;
         assert_eq!(
             check_result["allowed"],
@@ -635,7 +628,7 @@ async fn test_batch_check_handles_max_items() {
 
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": write_tuples
@@ -661,7 +654,7 @@ async fn test_batch_check_handles_max_items() {
 
     let (status, response) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/batch-check", store_id),
+        &format!("/stores/{store_id}/batch-check"),
         serde_json::json!({
             "checks": checks
         }),
@@ -673,11 +666,7 @@ async fn test_batch_check_handles_max_items() {
     let result = response["result"].as_object().unwrap();
     assert_eq!(result.len(), 50, "Should have 50 results");
     for i in 0..50 {
-        let check_result = &result[&format!("check-{}", i)];
-        assert_eq!(
-            check_result["allowed"], true,
-            "check-{} should be allowed",
-            i
-        );
+        let check_result = &result[&format!("check-{i}")];
+        assert_eq!(check_result["allowed"], true, "check-{i} should be allowed");
     }
 }

--- a/crates/rsfga-api/tests/stress_tests.rs
+++ b/crates/rsfga-api/tests/stress_tests.rs
@@ -62,7 +62,7 @@ async fn test_server_handles_1000_concurrent_requests() {
     // Write some tuples
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": [
@@ -92,7 +92,7 @@ async fn test_server_handles_1000_concurrent_requests() {
                 let app = create_test_app(&storage);
                 let (status, _) = post_json(
                     app,
-                    &format!("/stores/{}/check", store_id),
+                    &format!("/stores/{store_id}/check"),
                     serde_json::json!({
                         "tuple_key": {
                             "user": if i % 2 == 0 { "user:alice" } else { "user:bob" },
@@ -121,29 +121,21 @@ async fn test_server_handles_1000_concurrent_requests() {
     // Verify results
     assert_eq!(
         errors, 0,
-        "Should have no errors with {} concurrent requests",
-        STRESS_TEST_CONCURRENT_REQUESTS
+        "Should have no errors with {STRESS_TEST_CONCURRENT_REQUESTS} concurrent requests"
     );
     assert_eq!(
         successes, STRESS_TEST_CONCURRENT_REQUESTS as u64,
-        "All {} requests should succeed",
-        STRESS_TEST_CONCURRENT_REQUESTS
+        "All {STRESS_TEST_CONCURRENT_REQUESTS} requests should succeed"
     );
 
     // Performance check: should complete in reasonable time
     // Note: This is a soft assertion - actual performance depends on hardware
     assert!(
         elapsed < STRESS_TEST_TIMEOUT,
-        "{} concurrent requests should complete within {:?}, took {:?}",
-        STRESS_TEST_CONCURRENT_REQUESTS,
-        STRESS_TEST_TIMEOUT,
-        elapsed
+        "{STRESS_TEST_CONCURRENT_REQUESTS} concurrent requests should complete within {STRESS_TEST_TIMEOUT:?}, took {elapsed:?}"
     );
 
-    println!(
-        "Stress test completed: {} successes, {} errors in {:?}",
-        successes, errors, elapsed
-    );
+    println!("Stress test completed: {successes} successes, {errors} errors in {elapsed:?}");
 }
 
 /// Test: No memory leaks under sustained load (basic check)
@@ -173,7 +165,7 @@ async fn test_sustained_load_stability() {
     // Write test data
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": [
@@ -204,7 +196,7 @@ async fn test_sustained_load_stability() {
                     let app = create_test_app(&storage);
                     let (status, _) = post_json(
                         app,
-                        &format!("/stores/{}/check", store_id),
+                        &format!("/stores/{store_id}/check"),
                         serde_json::json!({
                             "tuple_key": {
                                 "user": "user:alice",
@@ -243,13 +235,11 @@ async fn test_sustained_load_stability() {
     // Verify reasonable throughput maintained
     assert!(
         total_requests > 100,
-        "Should process significant number of requests: got {}",
-        total_requests
+        "Should process significant number of requests: got {total_requests}"
     );
 
     println!(
-        "Sustained load test: {} requests in {:?} ({:.0} req/s), {} errors",
-        total_requests, elapsed, throughput, total_errors
+        "Sustained load test: {total_requests} requests in {elapsed:?} ({throughput:.0} req/s), {total_errors} errors"
     );
 }
 
@@ -280,7 +270,7 @@ async fn test_graceful_degradation_under_overload() {
     // Write test data
     let (status, _) = post_json(
         create_test_app(&storage),
-        &format!("/stores/{}/write", store_id),
+        &format!("/stores/{store_id}/write"),
         serde_json::json!({
             "writes": {
                 "tuple_keys": [
@@ -309,7 +299,7 @@ async fn test_graceful_degradation_under_overload() {
                 let app = create_test_app(&storage);
                 let (status, _) = post_json(
                     app,
-                    &format!("/stores/{}/check", store_id),
+                    &format!("/stores/{store_id}/check"),
                     serde_json::json!({
                         "tuple_key": {
                             "user": "user:alice",
@@ -346,8 +336,7 @@ async fn test_graceful_degradation_under_overload() {
     // We expect mostly successes for in-memory storage
     // Note: With rate limiting enabled, some 429s would be acceptable
     println!(
-        "Overload test: {} successes, {} client errors, {} server errors",
-        successes, client_errors, server_errors
+        "Overload test: {successes} successes, {client_errors} client errors, {server_errors} server errors"
     );
 
     // Verify the system processed most requests
@@ -414,7 +403,7 @@ async fn test_high_write_throughput() {
                 let app = create_test_app(&storage);
                 let (status, _) = post_json(
                     app,
-                    &format!("/stores/{}/write", store_id),
+                    &format!("/stores/{store_id}/write"),
                     serde_json::json!({
                         "writes": {
                             "tuple_keys": [

--- a/crates/rsfga-domain/benches/check_bench.rs
+++ b/crates/rsfga-domain/benches/check_bench.rs
@@ -58,7 +58,7 @@ impl BenchTupleReader {
         user_type: &str,
         user_id: &str,
     ) {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         let tuple = StoredTupleRef::new(user_type, user_id, None);
         self.tuples.entry(key).or_default().push(tuple);
     }
@@ -73,7 +73,7 @@ impl TupleReader for BenchTupleReader {
         object_id: &str,
         relation: &str,
     ) -> DomainResult<Vec<StoredTupleRef>> {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         Ok(self.tuples.get(&key).cloned().unwrap_or_default())
     }
 
@@ -111,7 +111,7 @@ impl ModelReader for BenchModelReader {
         store_id: &str,
         type_name: &str,
     ) -> DomainResult<TypeDefinition> {
-        let key = format!("{}:{}", store_id, type_name);
+        let key = format!("{store_id}:{type_name}");
         self.type_definitions
             .get(&key)
             .cloned()
@@ -172,7 +172,7 @@ fn create_direct_relation_setup() -> (Arc<BenchTupleReader>, Arc<BenchModelReade
         tuple_reader.add_tuple(
             "bench-store",
             "document",
-            &format!("doc{}", i),
+            &format!("doc{i}"),
             "viewer",
             "user",
             "alice",
@@ -232,7 +232,7 @@ fn create_union_relation_setup() -> (Arc<BenchTupleReader>, Arc<BenchModelReader
         tuple_reader.add_tuple(
             "bench-store",
             "document",
-            &format!("doc{}", i),
+            &format!("doc{i}"),
             "viewer",
             "user",
             "alice",
@@ -335,7 +335,7 @@ fn bench_repeated_check(c: &mut Criterion) {
                 "bench-store".to_string(),
                 "user:alice".to_string(),
                 "viewer".to_string(),
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
                 vec![],
             );
             let _ = resolver.check(&request).await;
@@ -444,7 +444,7 @@ fn bench_tuple_count_scalability(c: &mut Criterion) {
                 tuple_reader.add_tuple(
                     "bench-store",
                     "document",
-                    &format!("doc{}", i),
+                    &format!("doc{i}"),
                     "viewer",
                     "user",
                     "alice",
@@ -518,7 +518,7 @@ fn bench_cel_cache(c: &mut Criterion) {
     group.bench_function("cache_miss", |b| {
         b.iter(|| {
             counter += 1;
-            let expr = format!("x > {}", counter);
+            let expr = format!("x > {counter}");
             let result = cache_miss.get_or_parse(black_box(&expr));
             black_box(result)
         })

--- a/crates/rsfga-domain/src/cache/mod.rs
+++ b/crates/rsfga-domain/src/cache/mod.rs
@@ -657,7 +657,7 @@ mod tests {
 
         // Insert many entries that will expire
         for i in 0..50 {
-            let key = CacheKey::new("store-1", format!("doc:{}", i), "viewer", "user:alice");
+            let key = CacheKey::new("store-1", format!("doc:{i}"), "viewer", "user:alice");
             cache.insert(key, true).await;
         }
 
@@ -672,7 +672,7 @@ mod tests {
 
             // Perform multiple reads
             for i in 0..100 {
-                let key = CacheKey::new("store-1", format!("doc:{}", i), "viewer", "user:alice");
+                let key = CacheKey::new("store-1", format!("doc:{i}"), "viewer", "user:alice");
                 let _ = cache_clone.get(&key).await;
             }
 
@@ -683,8 +683,7 @@ mod tests {
         let read_duration = read_task.await.unwrap();
         assert!(
             read_duration < Duration::from_millis(100),
-            "Reads took too long: {:?}",
-            read_duration
+            "Reads took too long: {read_duration:?}"
         );
     }
 
@@ -750,7 +749,7 @@ mod tests {
         for i in 0..100 {
             let key = CacheKey::new(
                 "store-1",
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
                 "viewer",
                 "user:alice",
             );
@@ -772,8 +771,7 @@ mod tests {
         // Assert - spawning should be nearly instant (under 1ms)
         assert!(
             spawn_duration < Duration::from_millis(1),
-            "Spawning invalidation took too long: {:?}",
-            spawn_duration
+            "Spawning invalidation took too long: {spawn_duration:?}"
         );
 
         // Wait for invalidation to complete to verify it works
@@ -835,7 +833,7 @@ mod tests {
         for i in 0..10 {
             let key = CacheKey::new(
                 "store-1",
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
                 "viewer",
                 "user:alice",
             );
@@ -846,7 +844,7 @@ mod tests {
         let mut durations = Vec::new();
         for i in 0..10 {
             let duration = cache
-                .timed_invalidate_for_tuple("store-1", &format!("document:doc{}", i), "viewer")
+                .timed_invalidate_for_tuple("store-1", &format!("document:doc{i}"), "viewer")
                 .await;
             durations.push(duration);
         }
@@ -858,8 +856,7 @@ mod tests {
         // Note: In tests with small data, this should be well under 1ms
         assert!(
             *p99 < Duration::from_millis(100),
-            "Staleness window p99 too high: {:?}",
-            p99
+            "Staleness window p99 too high: {p99:?}"
         );
 
         // Log the measurement for informational purposes
@@ -883,7 +880,7 @@ mod tests {
         for i in 0..100 {
             let key = CacheKey::new(
                 "store-1",
-                format!("document:doc{}", i),
+                format!("document:doc{i}"),
                 "viewer",
                 "user:alice",
             );
@@ -901,7 +898,7 @@ mod tests {
                 for i in 0..100 {
                     let key = CacheKey::new(
                         "store-1",
-                        format!("document:doc{}", i),
+                        format!("document:doc{i}"),
                         "viewer",
                         "user:alice",
                     );
@@ -927,9 +924,7 @@ mod tests {
         for (task_id, duration) in &results {
             assert!(
                 *duration < Duration::from_millis(100),
-                "Task {} took too long: {:?}",
-                task_id,
-                duration
+                "Task {task_id} took too long: {duration:?}"
             );
         }
     }
@@ -950,7 +945,7 @@ mod tests {
                 for i in 0..100 {
                     let key = CacheKey::new(
                         "store-1",
-                        format!("document:task{}_doc{}", task_id, i),
+                        format!("document:task{task_id}_doc{i}"),
                         "viewer",
                         "user:alice",
                     );
@@ -975,16 +970,14 @@ mod tests {
             for i in 0..100 {
                 let key = CacheKey::new(
                     "store-1",
-                    format!("document:task{}_doc{}", task_id, i),
+                    format!("document:task{task_id}_doc{i}"),
                     "viewer",
                     "user:alice",
                 );
                 assert_eq!(
                     cache.get(&key).await,
                     Some(true),
-                    "Missing entry for task {} doc {}",
-                    task_id,
-                    i
+                    "Missing entry for task {task_id} doc {i}"
                 );
             }
         }
@@ -1021,8 +1014,7 @@ mod tests {
         // Assert - read should return either Some(false) or Some(true), never None or garbage
         assert!(
             read_result == Some(false) || read_result == Some(true),
-            "Got unexpected result: {:?}",
-            read_result
+            "Got unexpected result: {read_result:?}"
         );
     }
 
@@ -1066,8 +1058,7 @@ mod tests {
         // Assert - should complete within reasonable time (1 second for 1000 ops)
         assert!(
             duration < Duration::from_secs(1),
-            "1000 concurrent operations took too long: {:?}",
-            duration
+            "1000 concurrent operations took too long: {duration:?}"
         );
     }
 

--- a/crates/rsfga-domain/src/cel/cache.rs
+++ b/crates/rsfga-domain/src/cel/cache.rs
@@ -369,7 +369,7 @@ mod tests {
                 let cache_clone = Arc::clone(&cache);
                 thread::spawn(move || {
                     for j in 0..100 {
-                        let expr = format!("x{} > {}", i, j);
+                        let expr = format!("x{i} > {j}");
                         cache_clone.get_or_parse(&expr).unwrap();
                     }
                 })
@@ -410,8 +410,7 @@ mod tests {
         for (i, result) in results.iter().enumerate().skip(1) {
             assert!(
                 Arc::ptr_eq(first, result),
-                "Thread {} returned different Arc than thread 0 (race condition detected)",
-                i
+                "Thread {i} returned different Arc than thread 0 (race condition detected)"
             );
         }
 
@@ -431,7 +430,7 @@ mod tests {
 
         // Add 5 expressions (at capacity)
         for i in 0..5 {
-            cache.get_or_parse(&format!("x > {}", i)).unwrap();
+            cache.get_or_parse(&format!("x > {i}")).unwrap();
         }
         cache.run_pending_tasks();
         assert_eq!(cache.entry_count(), 5);

--- a/crates/rsfga-domain/src/cel/mod.rs
+++ b/crates/rsfga-domain/src/cel/mod.rs
@@ -244,10 +244,7 @@ mod tests {
             let result = CelExpression::parse(expr_str);
             assert!(
                 result.is_err(),
-                "Should reject invalid {} expression '{}' but got: {:?}",
-                desc,
-                expr_str,
-                result
+                "Should reject invalid {desc} expression '{expr_str}' but got: {result:?}"
             );
 
             // Verify error contains the original expression
@@ -262,8 +259,7 @@ mod tests {
                 );
                 assert!(
                     !message.is_empty(),
-                    "Error message should not be empty for '{}'",
-                    desc
+                    "Error message should not be empty for '{desc}'"
                 );
             }
         }
@@ -316,7 +312,7 @@ mod tests {
         let result = expr.evaluate(&ctx);
 
         // Assert
-        assert!(result.is_ok(), "Evaluation should succeed: {:?}", result);
+        assert!(result.is_ok(), "Evaluation should succeed: {result:?}");
         let eval_result = result.unwrap();
         assert_eq!(eval_result.as_bool(), Some(true));
     }
@@ -339,7 +335,7 @@ mod tests {
         ctx.set_map("context", context_map);
 
         let result = expr.evaluate(&ctx);
-        assert!(result.is_ok(), "Evaluation should succeed: {:?}", result);
+        assert!(result.is_ok(), "Evaluation should succeed: {result:?}");
         assert!(result.unwrap().is_truthy());
     }
 
@@ -356,7 +352,7 @@ mod tests {
         ctx.set_map("request", request_map);
 
         let result = expr.evaluate(&ctx);
-        assert!(result.is_ok(), "Evaluation should succeed: {:?}", result);
+        assert!(result.is_ok(), "Evaluation should succeed: {result:?}");
         assert!(result.unwrap().is_truthy());
     }
 
@@ -417,8 +413,7 @@ mod tests {
         let result = expr.evaluate(&ctx);
         assert!(
             result.is_ok(),
-            "Timestamp comparison should succeed: {:?}",
-            result
+            "Timestamp comparison should succeed: {result:?}"
         );
         assert!(result.unwrap().is_truthy());
     }
@@ -435,8 +430,7 @@ mod tests {
         let result = expr.evaluate(&ctx);
         assert!(
             result.is_ok(),
-            "Duration comparison should succeed: {:?}",
-            result
+            "Duration comparison should succeed: {result:?}"
         );
         assert!(result.unwrap().is_truthy());
     }
@@ -511,8 +505,7 @@ mod tests {
             .await;
         assert!(
             result.is_ok(),
-            "Normal evaluation should complete within timeout: {:?}",
-            result
+            "Normal evaluation should complete within timeout: {result:?}"
         );
         assert!(result.unwrap().is_truthy());
 
@@ -535,8 +528,7 @@ mod tests {
         // Production code should use reasonable timeouts (e.g., 100ms to 1s).
         assert!(
             result.is_ok() || matches!(result, Err(CelError::Timeout { .. })),
-            "Should either succeed quickly or timeout: {:?}",
-            result
+            "Should either succeed quickly or timeout: {result:?}"
         );
 
         // Test 3: Verify timeout error contains expression and duration
@@ -572,7 +564,7 @@ mod tests {
                 assert_eq!(*duration_ms, 0, "Duration should be captured");
             }
             Err(e) => {
-                panic!("Unexpected error type: {:?}", e);
+                panic!("Unexpected error type: {e:?}");
             }
         }
 

--- a/crates/rsfga-domain/src/model/types_proptest.rs
+++ b/crates/rsfga-domain/src/model/types_proptest.rs
@@ -7,13 +7,13 @@ mod tests {
     /// Strategy to generate valid user identifiers in type:id format
     fn valid_user_strategy() -> impl Strategy<Value = String> {
         // Generate type:id format like "user:alice" or "group:engineers"
-        ("[a-z]{1,10}", "[a-z0-9]{1,20}").prop_map(|(t, id)| format!("{}:{}", t, id))
+        ("[a-z]{1,10}", "[a-z0-9]{1,20}").prop_map(|(t, id)| format!("{t}:{id}"))
     }
 
     /// Strategy to generate valid userset references in type:id#relation format
     fn userset_reference_strategy() -> impl Strategy<Value = String> {
         ("[a-z]{1,10}", "[a-z0-9]{1,10}", "[a-z]{1,10}")
-            .prop_map(|(t, id, rel)| format!("{}:{}#{}", t, id, rel))
+            .prop_map(|(t, id, rel)| format!("{t}:{id}#{rel}"))
     }
 
     proptest! {
@@ -53,7 +53,7 @@ mod tests {
             obj_id in "[a-z0-9]{1,10}"
         ) {
             use crate::model::Object;
-            let input = format!("{}:{}", obj_type, obj_id);
+            let input = format!("{obj_type}:{obj_id}");
             let parsed = Object::parse(&input);
             prop_assert!(parsed.is_ok());
             let obj = parsed.unwrap();
@@ -68,7 +68,7 @@ mod tests {
             object in "[a-z0-9:]{3,20}"
         ) {
             use crate::model::Tuple;
-            let user = format!("{}:{}", user_type, user_id);
+            let user = format!("{user_type}:{user_id}");
             // Non-empty strings for all fields should succeed
             if !relation.is_empty() && !object.is_empty() {
                 let tuple = Tuple::new(&user, &relation, &object);

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -975,7 +975,7 @@ where
             model
                 .find_condition(condition_name)
                 .ok_or_else(|| DomainError::ResolverError {
-                    message: format!("condition not found: {}", condition_name),
+                    message: format!("condition not found: {condition_name}"),
                 })?;
 
         // Get the parsed CEL expression from cache (or parse and cache it)

--- a/crates/rsfga-domain/src/resolver/tests/mocks.rs
+++ b/crates/rsfga-domain/src/resolver/tests/mocks.rs
@@ -39,7 +39,7 @@ impl MockTupleReader {
         user_id: &str,
         user_relation: Option<&str>,
     ) {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         let tuple = StoredTupleRef::new(user_type, user_id, user_relation.map(|s| s.to_string()));
         self.tuples
             .write()
@@ -59,7 +59,7 @@ impl MockTupleReader {
         user_type: &str,
         user_id: &str,
     ) {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         if let Some(tuples) = self.tuples.write().await.get_mut(&key) {
             tuples.retain(|t| t.user_type != user_type || t.user_id != user_id);
         }
@@ -79,7 +79,7 @@ impl MockTupleReader {
         condition_name: &str,
         condition_context: Option<HashMap<String, serde_json::Value>>,
     ) {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         let tuple = StoredTupleRef::with_condition(
             user_type,
             user_id,
@@ -105,7 +105,7 @@ impl TupleReader for MockTupleReader {
         object_id: &str,
         relation: &str,
     ) -> DomainResult<Vec<StoredTupleRef>> {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         Ok(self
             .tuples
             .read()
@@ -167,7 +167,7 @@ impl ModelReader for MockModelReader {
         store_id: &str,
         type_name: &str,
     ) -> DomainResult<TypeDefinition> {
-        let key = format!("{}:{}", store_id, type_name);
+        let key = format!("{store_id}:{type_name}");
         self.type_definitions
             .read()
             .await

--- a/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
+++ b/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
@@ -728,14 +728,14 @@ async fn test_union_executes_branches_in_parallel() {
     let mut children = vec![];
     for i in 0..10 {
         children.push(Userset::ComputedUserset {
-            relation: format!("branch{}", i),
+            relation: format!("branch{i}"),
         });
     }
 
     let mut relations = vec![];
     for i in 0..10 {
         relations.push(RelationDefinition {
-            name: format!("branch{}", i),
+            name: format!("branch{i}"),
             type_constraints: vec!["user".into()],
             rewrite: Userset::This,
         });
@@ -905,8 +905,7 @@ async fn test_union_returns_cycle_error_when_all_branches_cycle() {
     let result = resolver.check(&request).await;
     assert!(
         matches!(result, Err(DomainError::CycleDetected { .. })),
-        "Union with all cyclic branches should return CycleDetected error, got {:?}",
-        result
+        "Union with all cyclic branches should return CycleDetected error, got {result:?}"
     );
 }
 
@@ -1019,8 +1018,7 @@ async fn test_union_returns_false_when_one_branch_false_and_other_depth_limit() 
     let result = resolver.check(&request).await;
     assert!(
         matches!(result, Ok(CheckResult { allowed: false })),
-        "Union with one false branch and one depth-limited branch should return false, got {:?}",
-        result
+        "Union with one false branch and one depth-limited branch should return false, got {result:?}"
     );
 }
 
@@ -1097,8 +1095,7 @@ async fn test_union_returns_depth_limit_error_when_all_branches_hit_depth_limit(
             result,
             Err(DomainError::DepthLimitExceeded { .. }) | Err(DomainError::CycleDetected { .. })
         ),
-        "Union with all depth-limited branches should return path-termination error, got {:?}",
-        result
+        "Union with all depth-limited branches should return path-termination error, got {result:?}"
     );
 }
 
@@ -1255,14 +1252,14 @@ async fn test_intersection_executes_branches_in_parallel() {
     let mut children = vec![];
     for i in 0..5 {
         children.push(Userset::ComputedUserset {
-            relation: format!("req{}", i),
+            relation: format!("req{i}"),
         });
     }
 
     let mut relations = vec![];
     for i in 0..5 {
         relations.push(RelationDefinition {
-            name: format!("req{}", i),
+            name: format!("req{i}"),
             type_constraints: vec!["user".into()],
             rewrite: Userset::This,
         });
@@ -1290,7 +1287,7 @@ async fn test_intersection_executes_branches_in_parallel() {
                 "store1",
                 "document",
                 "doc1",
-                &format!("req{}", i),
+                &format!("req{i}"),
                 "user",
                 "alice",
                 None,
@@ -1579,8 +1576,7 @@ async fn test_exclusion_returns_false_when_base_false_despite_subtract_cycle() {
     let result = resolver.check(&request).await;
     assert!(
         result.is_ok(),
-        "Exclusion with base=false should not error despite cyclic subtract: {:?}",
-        result
+        "Exclusion with base=false should not error despite cyclic subtract: {result:?}"
     );
     assert!(
         !result.unwrap().allowed,
@@ -1663,8 +1659,7 @@ async fn test_exclusion_returns_false_when_subtract_true_despite_base_cycle() {
     let result = resolver.check(&request).await;
     assert!(
         result.is_ok(),
-        "Exclusion with subtract=true should not error despite cyclic base: {:?}",
-        result
+        "Exclusion with subtract=true should not error despite cyclic base: {result:?}"
     );
     assert!(
         !result.unwrap().allowed,
@@ -1747,8 +1742,7 @@ async fn test_exclusion_returns_cycle_error_when_both_branches_cycle() {
     let result = resolver.check(&request).await;
     assert!(
         matches!(result, Err(DomainError::CycleDetected { .. })),
-        "Exclusion with both cyclic branches should return CycleDetected, got {:?}",
-        result
+        "Exclusion with both cyclic branches should return CycleDetected, got {result:?}"
     );
 }
 
@@ -1825,8 +1819,7 @@ async fn test_exclusion_propagates_error_when_base_true_and_subtract_errors() {
     let result = resolver.check(&request).await;
     assert!(
         matches!(result, Err(DomainError::CycleDetected { .. })),
-        "Exclusion with base=true and cyclic subtract should return error, got {:?}",
-        result
+        "Exclusion with base=true and cyclic subtract should return error, got {result:?}"
     );
 }
 
@@ -1979,7 +1972,7 @@ async fn test_depth_limit_prevents_stack_overflow() {
 
     // Create deep chain: level0.viewer -> level1.viewer -> ... -> levelN.viewer
     for i in 0..30 {
-        let type_name = format!("level{}", i);
+        let type_name = format!("level{i}");
         let rewrite = if i == 0 {
             Userset::This
         } else {
@@ -2019,7 +2012,7 @@ async fn test_depth_limit_prevents_stack_overflow() {
         tuple_reader
             .add_tuple(
                 "store1",
-                &format!("level{}", i),
+                &format!("level{i}"),
                 "obj",
                 "parent",
                 &format!("level{}", i - 1),
@@ -2068,7 +2061,7 @@ async fn test_returns_depth_limit_exceeded_error() {
 
     // Create chain that exceeds depth limit
     for i in 0..30 {
-        let type_name = format!("type{}", i);
+        let type_name = format!("type{i}");
         model_reader
             .add_type(
                 "store1",
@@ -2102,7 +2095,7 @@ async fn test_returns_depth_limit_exceeded_error() {
         tuple_reader
             .add_tuple(
                 "store1",
-                &format!("type{}", i),
+                &format!("type{i}"),
                 "obj",
                 "parent",
                 &format!("type{}", i - 1),
@@ -2430,7 +2423,7 @@ async fn test_returns_timeout_error_with_context() {
         Err(DomainError::Timeout { duration_ms }) => {
             assert_eq!(duration_ms, 50);
         }
-        _ => panic!("Expected Timeout error, got {:?}", result),
+        _ => panic!("Expected Timeout error, got {result:?}"),
     }
 }
 
@@ -2520,7 +2513,7 @@ async fn test_depth_limit_at_boundary_24_succeeds() {
 
     // Create chain of exactly 24 levels
     for i in 0..25 {
-        let type_name = format!("level{}", i);
+        let type_name = format!("level{i}");
         let rewrite = if i == 0 {
             Userset::This
         } else {
@@ -2560,7 +2553,7 @@ async fn test_depth_limit_at_boundary_24_succeeds() {
         tuple_reader
             .add_tuple(
                 "store1",
-                &format!("level{}", i),
+                &format!("level{i}"),
                 "obj",
                 "parent",
                 &format!("level{}", i - 1),
@@ -2999,18 +2992,13 @@ use proptest::prelude::*;
 
 /// Strategy to generate valid user identifiers
 fn user_strategy() -> impl Strategy<Value = String> {
-    "[a-z]{1,10}".prop_map(|s| format!("user:{}", s))
+    "[a-z]{1,10}".prop_map(|s| format!("user:{s}"))
 }
 
 /// Strategy to generate valid object identifiers
 fn object_strategy() -> impl Strategy<Value = (String, String, String)> {
-    ("[a-z]{1,10}", "[a-z0-9]{1,10}").prop_map(|(type_name, id)| {
-        (
-            type_name.clone(),
-            id.clone(),
-            format!("{}:{}", type_name, id),
-        )
-    })
+    ("[a-z]{1,10}", "[a-z0-9]{1,10}")
+        .prop_map(|(type_name, id)| (type_name.clone(), id.clone(), format!("{type_name}:{id}")))
 }
 
 /// Strategy to generate valid relation names
@@ -3170,9 +3158,9 @@ proptest! {
 
             let request = CheckRequest {
                 store_id: "store1".to_string(),
-                user: format!("user:{}", user_name),
+                user: format!("user:{user_name}"),
                 relation: "viewer".to_string(),
-                object: format!("document:{}", object_id),
+                object: format!("document:{object_id}"),
                 contextual_tuples: Arc::new(vec![]),
                 context: Arc::new(std::collections::HashMap::new()),
             };
@@ -3223,9 +3211,9 @@ proptest! {
             // Check for user before adding tuple for OTHER user
             let request = CheckRequest {
                 store_id: "store1".to_string(),
-                user: format!("user:{}", user_name),
+                user: format!("user:{user_name}"),
                 relation: "viewer".to_string(),
-                object: format!("document:{}", object_id),
+                object: format!("document:{object_id}"),
                 contextual_tuples: Arc::new(vec![]),
                 context: Arc::new(std::collections::HashMap::new()),
             };
@@ -3291,9 +3279,9 @@ proptest! {
             // Check access to other_object before deleting tuple for object_id
             let request = CheckRequest {
                 store_id: "store1".to_string(),
-                user: format!("user:{}", user_name),
+                user: format!("user:{user_name}"),
                 relation: "viewer".to_string(),
-                object: format!("document:{}", other_object),
+                object: format!("document:{other_object}"),
                 contextual_tuples: Arc::new(vec![]),
                 context: Arc::new(std::collections::HashMap::new()),
             };
@@ -3514,11 +3502,10 @@ async fn test_check_without_required_context_returns_error() {
         DomainError::ResolverError { message } => {
             assert!(
                 message.contains("condition evaluation failed"),
-                "Error should indicate condition evaluation failed: {}",
-                message
+                "Error should indicate condition evaluation failed: {message}"
             );
         }
-        _ => panic!("Expected ResolverError but got: {:?}", error),
+        _ => panic!("Expected ResolverError but got: {error:?}"),
     }
 }
 
@@ -4092,8 +4079,7 @@ async fn test_check_returns_error_for_nonexistent_condition() {
     let err = result.expect_err("Should return error when condition is not found in model");
     assert!(
         err.to_string().contains("condition not found"),
-        "Error message should indicate condition not found: {}",
-        err
+        "Error message should indicate condition not found: {err}"
     );
 }
 
@@ -4167,8 +4153,7 @@ async fn test_check_returns_error_for_invalid_cel_expression() {
         assert!(
             err.to_string().contains("failed to parse")
                 || err.to_string().contains("condition evaluation failed"),
-            "Error should indicate CEL parse/eval failure: {}",
-            err
+            "Error should indicate CEL parse/eval failure: {err}"
         );
     }
 }
@@ -4820,7 +4805,7 @@ async fn test_cache_timeout_wrapper_does_not_break_normal_operation() {
     // Perform 100 checks to stress test the timeout wrapper
     for i in 0..100 {
         let result = resolver.check(&request).await.unwrap();
-        assert!(result.allowed, "Check {} should be allowed", i);
+        assert!(result.allowed, "Check {i} should be allowed");
     }
 
     // Verify metrics: 1 miss + 99 hits, 0 skips (no timeouts occurred)

--- a/crates/rsfga-server/benches/batch_handler_bench.rs
+++ b/crates/rsfga-server/benches/batch_handler_bench.rs
@@ -47,7 +47,7 @@ impl BenchTupleReader {
         user_type: &str,
         user_id: &str,
     ) {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         let tuple = StoredTupleRef::new(user_type, user_id, None);
         self.tuples.entry(key).or_default().push(tuple);
     }
@@ -62,7 +62,7 @@ impl TupleReader for BenchTupleReader {
         object_id: &str,
         relation: &str,
     ) -> DomainResult<Vec<StoredTupleRef>> {
-        let key = format!("{}:{}:{}:{}", store_id, object_type, object_id, relation);
+        let key = format!("{store_id}:{object_type}:{object_id}:{relation}");
         Ok(self.tuples.get(&key).cloned().unwrap_or_default())
     }
 
@@ -100,7 +100,7 @@ impl ModelReader for BenchModelReader {
         store_id: &str,
         type_name: &str,
     ) -> DomainResult<TypeDefinition> {
-        let key = format!("{}:{}", store_id, type_name);
+        let key = format!("{store_id}:{type_name}");
         self.type_definitions
             .get(&key)
             .cloned()
@@ -160,10 +160,10 @@ fn create_batch_check_setup() -> (Arc<BenchTupleReader>, Arc<BenchModelReader>) 
             tuple_reader.add_tuple(
                 "bench-store",
                 "document",
-                &format!("doc{}", doc_id),
+                &format!("doc{doc_id}"),
                 "viewer",
                 "user",
-                &format!("user{}", user_id),
+                &format!("user{user_id}"),
             );
         }
     }
@@ -189,7 +189,7 @@ fn generate_batch_with_duplicates(batch_size: usize, duplicate_ratio: f64) -> Ve
             BatchCheckItem {
                 user: "user:user0".to_string(),
                 relation: "viewer".to_string(),
-                object: format!("document:doc{}", doc_idx),
+                object: format!("document:doc{doc_idx}"),
             }
         })
         .collect()
@@ -316,7 +316,7 @@ fn bench_deduplication_benefit(c: &mut Criterion) {
         .map(|i| BatchCheckItem {
             user: format!("user:user{}", i % 10),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
 

--- a/crates/rsfga-server/src/config.rs
+++ b/crates/rsfga-server/src/config.rs
@@ -509,15 +509,14 @@ storage:
             let result = config.validate();
 
             if should_err {
-                assert!(result.is_err(), "Expected error for backend '{}'", backend);
+                assert!(result.is_err(), "Expected error for backend '{backend}'");
                 let err = result.unwrap_err();
                 assert!(
                     err.to_string().contains("database_url"),
-                    "Error for '{}' should contain 'database_url'",
-                    backend
+                    "Error for '{backend}' should contain 'database_url'"
                 );
             } else {
-                assert!(result.is_ok(), "Expected ok for backend '{}'", backend);
+                assert!(result.is_ok(), "Expected ok for backend '{backend}'");
             }
         }
 

--- a/crates/rsfga-server/src/handlers/batch/handler.rs
+++ b/crates/rsfga-server/src/handlers/batch/handler.rs
@@ -251,8 +251,7 @@ where
                             return BatchCheckItemResult {
                                 allowed: false,
                                 error: Some(format!(
-                                    "singleflight retry limit exceeded ({} retries)",
-                                    MAX_SINGLEFLIGHT_RETRIES
+                                    "singleflight retry limit exceeded ({MAX_SINGLEFLIGHT_RETRIES} retries)"
                                 )),
                             };
                         }

--- a/crates/rsfga-server/src/handlers/batch/tests.rs
+++ b/crates/rsfga-server/src/handlers/batch/tests.rs
@@ -240,9 +240,9 @@ fn test_accepts_batch_near_max_size() {
     let handler = create_test_handler();
     let checks: Vec<BatchCheckItem> = (0..45) // Below MAX_BATCH_SIZE (50)
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
     let request = BatchCheckRequest::new("store1", checks);
@@ -261,9 +261,9 @@ fn test_rejects_batch_exceeding_max_size() {
     let handler = create_test_handler();
     let checks: Vec<BatchCheckItem> = (0..51) // MAX_BATCH_SIZE + 1
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
     let request = BatchCheckRequest::new("store1", checks);
@@ -288,9 +288,9 @@ fn test_accepts_batch_at_max_size() {
     let handler = create_test_handler();
     let checks: Vec<BatchCheckItem> = (0..MAX_BATCH_SIZE)
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
     let request = BatchCheckRequest::new("store1", checks);
@@ -986,8 +986,7 @@ async fn test_unique_checks_execute_in_parallel() {
     // If parallel, total time should be ~50ms (not 5*50=250ms)
     assert!(
         elapsed < Duration::from_millis(200),
-        "Parallel execution should be faster than sequential, took {:?}",
-        elapsed
+        "Parallel execution should be faster than sequential, took {elapsed:?}"
     );
 }
 
@@ -1044,9 +1043,9 @@ async fn test_batch_processes_faster_than_sequential() {
     // Create batch with 10 unique checks
     let checks: Vec<BatchCheckItem> = (0..10)
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
     let request = BatchCheckRequest::new("store1", checks);
@@ -1064,8 +1063,7 @@ async fn test_batch_processes_faster_than_sequential() {
     // Use 150ms as threshold to account for some overhead
     assert!(
         elapsed < Duration::from_millis(150),
-        "Batch should be faster than sequential (10*20ms=200ms), took {:?}",
-        elapsed
+        "Batch should be faster than sequential (10*20ms=200ms), took {elapsed:?}"
     );
 }
 
@@ -1133,9 +1131,9 @@ async fn test_parallel_execution_uses_all_available_concurrency() {
     // Create batch with MAX_BATCH_SIZE unique checks
     let checks: Vec<BatchCheckItem> = (0..MAX_BATCH_SIZE)
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
     let request = BatchCheckRequest::new("store1", checks);
@@ -1147,8 +1145,7 @@ async fn test_parallel_execution_uses_all_available_concurrency() {
     let max = max_concurrent.load(Ordering::SeqCst);
     assert!(
         max > 1,
-        "Checks should execute in parallel, max concurrent was {}",
-        max
+        "Checks should execute in parallel, max concurrent was {max}"
     );
     // TODO(#86): When explicit concurrency limits are added (e.g., MAX_CONCURRENT = 32),
     // add assertion: assert!(max <= MAX_CONCURRENT, "Should respect limit");
@@ -1171,7 +1168,7 @@ async fn test_handles_partial_failures_gracefully() {
             // Fail for odd document numbers
             if object_id.ends_with('1') || object_id.ends_with('3') {
                 Err(DomainError::ResolverError {
-                    message: format!("failed for {}", object_id),
+                    message: format!("failed for {object_id}"),
                 })
             } else {
                 Ok(vec![StoredTupleRef {
@@ -1340,8 +1337,7 @@ async fn test_batch_of_max_identical_checks_executes_only_once() {
     let actual_calls = call_count.load(Ordering::SeqCst);
     assert_eq!(
         actual_calls, 1,
-        "{} identical checks should execute only 1 check, got {}",
-        MAX_BATCH_SIZE, actual_calls
+        "{MAX_BATCH_SIZE} identical checks should execute only 1 check, got {actual_calls}"
     );
 }
 
@@ -1422,14 +1418,12 @@ async fn test_batch_throughput_target() {
     // In production benchmarks (M1.8), we'll validate the actual target
     assert!(
         checks_per_second > 100.0, // Conservative threshold for CI
-        "Batch throughput should be reasonable, got {:.0} checks/s",
-        checks_per_second
+        "Batch throughput should be reasonable, got {checks_per_second:.0} checks/s"
     );
 
     // Log actual throughput for visibility (won't cause test failure)
     println!(
-        "Batch throughput: {:.0} checks/s ({} checks in {:?})",
-        checks_per_second, MAX_BATCH_SIZE, elapsed
+        "Batch throughput: {checks_per_second:.0} checks/s ({MAX_BATCH_SIZE} checks in {elapsed:?})"
     );
 }
 
@@ -1587,9 +1581,9 @@ async fn test_batch_handler_respects_runtime_concurrency() {
     // Create batch with 20 unique checks (much more than concurrency limit)
     let checks: Vec<BatchCheckItem> = (0..20)
         .map(|i| BatchCheckItem {
-            user: format!("user:user{}", i),
+            user: format!("user:user{i}"),
             relation: "viewer".to_string(),
-            object: format!("document:doc{}", i),
+            object: format!("document:doc{i}"),
         })
         .collect();
 
@@ -1600,15 +1594,12 @@ async fn test_batch_handler_respects_runtime_concurrency() {
     let observed_max = max_concurrent.load(Ordering::SeqCst);
     assert!(
         observed_max <= concurrency_limit,
-        "Max concurrent {} exceeded limit {}",
-        observed_max,
-        concurrency_limit
+        "Max concurrent {observed_max} exceeded limit {concurrency_limit}"
     );
 
     // Also verify that some parallelism did occur (max > 1)
     assert!(
         observed_max > 1,
-        "Expected some parallelism (max > 1), but got {}",
-        observed_max
+        "Expected some parallelism (max > 1), but got {observed_max}"
     );
 }

--- a/crates/rsfga-storage/src/memory.rs
+++ b/crates/rsfga-storage/src/memory.rs
@@ -839,10 +839,10 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 let tuple = StoredTuple {
                     object_type: "document".to_string(),
-                    object_id: format!("doc{}", i),
+                    object_id: format!("doc{i}"),
                     relation: "viewer".to_string(),
                     user_type: "user".to_string(),
-                    user_id: format!("user{}", i),
+                    user_id: format!("user{i}"),
                     user_relation: None,
                     condition_name: None,
                     condition_context: None,
@@ -876,10 +876,10 @@ mod tests {
         for i in 0..50 {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -896,10 +896,10 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 let tuple = StoredTuple {
                     object_type: "document".to_string(),
-                    object_id: format!("doc{}", i),
+                    object_id: format!("doc{i}"),
                     relation: "viewer".to_string(),
                     user_type: "user".to_string(),
-                    user_id: format!("user{}", i),
+                    user_id: format!("user{i}"),
                     user_relation: None,
                     condition_name: None,
                     condition_context: None,
@@ -1080,10 +1080,10 @@ mod tests {
         for i in 0..10 {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -1136,7 +1136,7 @@ mod tests {
         // Create 5 stores
         for i in 0..5 {
             store
-                .create_store(&format!("store{}", i), &format!("Store {}", i))
+                .create_store(&format!("store{i}"), &format!("Store {i}"))
                 .await
                 .unwrap();
         }
@@ -1181,10 +1181,10 @@ mod tests {
                 } else {
                     "folder".to_string()
                 },
-                object_id: format!("obj{}", i),
+                object_id: format!("obj{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -1723,7 +1723,7 @@ mod tests {
         let handles: Vec<_> = (0..num_tasks)
             .map(|i| {
                 let store = Arc::clone(&store);
-                let name = format!("Store {}", i);
+                let name = format!("Store {i}");
                 tokio::spawn(async move { store.create_store(store_id, &name).await })
             })
             .collect();
@@ -1758,8 +1758,7 @@ mod tests {
         for failure in failures {
             assert!(
                 matches!(failure, Err(StorageError::StoreAlreadyExists { .. })),
-                "Expected StoreAlreadyExists error, got {:?}",
-                failure
+                "Expected StoreAlreadyExists error, got {failure:?}"
             );
         }
 

--- a/crates/rsfga-storage/src/mysql.rs
+++ b/crates/rsfga-storage/src/mysql.rs
@@ -1785,7 +1785,7 @@ mod tests {
             database_url: "mysql://user:password@localhost/rsfga".to_string(),
             ..Default::default()
         };
-        let debug_output = format!("{:?}", config);
+        let debug_output = format!("{config:?}");
         assert!(debug_output.contains("[REDACTED]"));
         assert!(!debug_output.contains("password"));
         // Should include timeout and batch size fields

--- a/crates/rsfga-storage/src/postgres.rs
+++ b/crates/rsfga-storage/src/postgres.rs
@@ -1748,7 +1748,7 @@ mod tests {
             ..Default::default()
         };
 
-        let debug_str = format!("{:?}", config);
+        let debug_str = format!("{config:?}");
         assert!(debug_str.contains("[REDACTED]"));
         assert!(!debug_str.contains("password"));
         // Should include new timeout fields

--- a/crates/rsfga-storage/tests/cockroachdb_integration.rs
+++ b/crates/rsfga-storage/tests/cockroachdb_integration.rs
@@ -512,7 +512,7 @@ async fn test_pagination_on_cockroachdb() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{:02}", i),
+                format!("doc{i:02}"),
                 "viewer",
                 "user",
                 "alice",
@@ -590,10 +590,10 @@ async fn test_concurrent_writes_on_cockroachdb() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
-                format!("user{}", i),
+                format!("user{i}"),
                 None,
             );
             store
@@ -641,7 +641,7 @@ async fn test_cockroachdb_basic_consistency() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 "alice",
@@ -685,7 +685,7 @@ async fn test_large_batch_on_cockroachdb() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 format!("user{}", i % 100),
@@ -731,7 +731,7 @@ async fn test_large_dataset_performance_cockroachdb() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 format!("user{}", i % 500),
@@ -758,10 +758,7 @@ async fn test_large_dataset_performance_cockroachdb() {
     assert_eq!(result.len(), 10_000);
 
     // Log performance (not asserted to avoid flaky tests)
-    eprintln!(
-        "CockroachDB 10k tuples: write={:?}, read={:?}",
-        write_duration, read_duration
-    );
+    eprintln!("CockroachDB 10k tuples: write={write_duration:?}, read={read_duration:?}");
 
     // Test filtered query performance
     let filter = TupleFilter {
@@ -777,7 +774,7 @@ async fn test_large_dataset_performance_cockroachdb() {
 
     // user42 appears at indices 42, 542, 1042, ... (every 500)
     assert_eq!(filtered.len(), 20);
-    eprintln!("CockroachDB filtered query: {:?}", filter_duration);
+    eprintln!("CockroachDB filtered query: {filter_duration:?}");
 
     // Cleanup
     store.delete_store("test-crdb-large-dataset").await.unwrap();
@@ -838,10 +835,10 @@ async fn test_pool_exhaustion_on_cockroachdb() {
             // some will timeout
             let tuple = StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
-                format!("user{}", i),
+                format!("user{i}"),
                 None,
             );
             store.write_tuple("test-crdb-pool-exhaustion", tuple).await
@@ -864,8 +861,7 @@ async fn test_pool_exhaustion_on_cockroachdb() {
                         || error_msg.contains("pool")
                         || error_msg.contains("connection")
                         || error_msg.contains("timed out"),
-                    "Expected pool exhaustion error, got: {}",
-                    e
+                    "Expected pool exhaustion error, got: {e}"
                 );
             }
         }
@@ -873,10 +869,7 @@ async fn test_pool_exhaustion_on_cockroachdb() {
 
     // Some operations should succeed (pool has 2 connections)
     // Others may fail due to pool exhaustion (depends on timing)
-    eprintln!(
-        "CockroachDB pool exhaustion test: {} succeeded, {} failed",
-        success_count, error_count
-    );
+    eprintln!("CockroachDB pool exhaustion test: {success_count} succeeded, {error_count} failed");
 
     // At minimum, some should succeed
     assert!(success_count > 0, "At least some operations should succeed");
@@ -922,7 +915,7 @@ async fn test_pool_recovery_on_cockroachdb() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple::new(
                 "document",
-                format!("phase1-doc{}", i),
+                format!("phase1-doc{i}"),
                 "viewer",
                 "user",
                 "alice",
@@ -941,7 +934,7 @@ async fn test_pool_recovery_on_cockroachdb() {
     for i in 0..5 {
         let tuple = StoredTuple::new(
             "document",
-            format!("phase2-doc{}", i),
+            format!("phase2-doc{i}"),
             "viewer",
             "user",
             "bob",
@@ -995,7 +988,7 @@ async fn test_concurrent_migrations_on_cockroachdb() {
             let store = PostgresDataStore::from_config(&config).await?;
             store.run_migrations().await?;
 
-            eprintln!("CockroachDB migration instance {} completed", i);
+            eprintln!("CockroachDB migration instance {i} completed");
             Ok::<_, StorageError>(())
         }));
     }
@@ -1020,11 +1013,11 @@ async fn test_concurrent_migrations_on_cockroachdb() {
             Ok(Ok(())) => success_count += 1,
             Ok(Err(e)) => {
                 // Migration errors are acceptable (e.g., if table already exists)
-                eprintln!("CockroachDB migration error (acceptable): {}", e);
+                eprintln!("CockroachDB migration error (acceptable): {e}");
                 success_count += 1; // Still counts as completing without deadlock
             }
             Err(e) => {
-                panic!("Task join error: {}", e);
+                panic!("Task join error: {e}");
             }
         }
     }

--- a/crates/rsfga-storage/tests/mariadb_integration.rs
+++ b/crates/rsfga-storage/tests/mariadb_integration.rs
@@ -91,7 +91,7 @@ impl MariaDbContainer {
         let container = Mariadb::default().start().await.unwrap();
         let host_port = container.get_host_port_ipv4(3306).await.unwrap();
         // Default MariaDB image uses root with no password
-        let connection_string = format!("mysql://root@127.0.0.1:{}/test", host_port);
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
         Self {
             container,
             connection_string,
@@ -372,7 +372,7 @@ async fn testcontainers_mariadb_pagination() {
     for i in 0..10 {
         let tuple = StoredTuple::new(
             "document",
-            format!("doc{}", i),
+            format!("doc{i}"),
             "viewer",
             "user",
             "alice",

--- a/crates/rsfga-storage/tests/mysql_integration.rs
+++ b/crates/rsfga-storage/tests/mysql_integration.rs
@@ -330,10 +330,10 @@ async fn test_connection_pool_limits() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -442,10 +442,10 @@ async fn test_concurrent_writes_isolation() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -488,10 +488,10 @@ async fn test_concurrent_access_across_threads() {
             for j in 0..100 {
                 let tuple = StoredTuple {
                     object_type: "doc".to_string(),
-                    object_id: format!("doc-{}-{}", i, j),
+                    object_id: format!("doc-{i}-{j}"),
                     relation: "viewer".to_string(),
                     user_type: "user".to_string(),
-                    user_id: format!("user-{}", i),
+                    user_id: format!("user-{i}"),
                     user_relation: None,
                     condition_name: None,
                     condition_context: None,
@@ -536,7 +536,7 @@ async fn test_batch_insert_large_batch_chunking() {
     let tuples: Vec<StoredTuple> = (0..1500)
         .map(|i| StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("batch-doc-{}", i),
+            object_id: format!("batch-doc-{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("batch-user-{}", i % 50), // 50 unique users
@@ -593,7 +593,7 @@ async fn test_batch_delete_large_batch_chunking() {
     let tuples: Vec<StoredTuple> = (0..1500)
         .map(|i| StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("delete-doc-{}", i),
+            object_id: format!("delete-doc-{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("delete-user-{}", i % 50),
@@ -727,7 +727,7 @@ async fn test_large_dataset_performance() {
     for i in 0..10_000 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{}", i),
+            object_id: format!("doc{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("user{}", i % 100), // 100 unique users
@@ -821,25 +821,21 @@ async fn test_indexes_created() {
     // Check for our custom indexes
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_store")),
-        "Missing store index. Found: {:?}",
-        index_names
+        "Missing store index. Found: {index_names:?}"
     );
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_object")),
-        "Missing object index. Found: {:?}",
-        index_names
+        "Missing object index. Found: {index_names:?}"
     );
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_user")),
-        "Missing user index. Found: {:?}",
-        index_names
+        "Missing user index. Found: {index_names:?}"
     );
     assert!(
         index_names
             .iter()
             .any(|n| n.contains("idx_tuples_relation")),
-        "Missing relation index. Found: {:?}",
-        index_names
+        "Missing relation index. Found: {index_names:?}"
     );
 }
 
@@ -890,10 +886,10 @@ async fn test_large_result_set_pagination() {
     for i in 0..100 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{:03}", i),
+            object_id: format!("doc{i:03}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
-            user_id: format!("user{:03}", i),
+            user_id: format!("user{i:03}"),
             user_relation: None,
             condition_name: None,
             condition_context: None,
@@ -1107,10 +1103,10 @@ async fn test_pool_exhaustion_returns_timeout_error() {
             // some will timeout
             let tuple = StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
-                format!("user{}", i),
+                format!("user{i}"),
                 None,
             );
             store.write_tuple("test-pool-exhaustion", tuple).await
@@ -1133,8 +1129,7 @@ async fn test_pool_exhaustion_returns_timeout_error() {
                         || error_msg.contains("pool")
                         || error_msg.contains("connection")
                         || error_msg.contains("timed out"),
-                    "Expected pool exhaustion error, got: {}",
-                    e
+                    "Expected pool exhaustion error, got: {e}"
                 );
             }
         }
@@ -1142,10 +1137,7 @@ async fn test_pool_exhaustion_returns_timeout_error() {
 
     // Some operations should succeed (pool has 2 connections)
     // Others may fail due to pool exhaustion (depends on timing)
-    eprintln!(
-        "Pool exhaustion test: {} succeeded, {} failed",
-        success_count, error_count
-    );
+    eprintln!("Pool exhaustion test: {success_count} succeeded, {error_count} failed");
 
     // At minimum, some should succeed
     assert!(success_count > 0, "At least some operations should succeed");
@@ -1191,7 +1183,7 @@ async fn test_pool_recovers_after_queries_complete() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple::new(
                 "document",
-                format!("phase1-doc{}", i),
+                format!("phase1-doc{i}"),
                 "viewer",
                 "user",
                 "alice",
@@ -1210,7 +1202,7 @@ async fn test_pool_recovers_after_queries_complete() {
     for i in 0..5 {
         let tuple = StoredTuple::new(
             "document",
-            format!("phase2-doc{}", i),
+            format!("phase2-doc{i}"),
             "viewer",
             "user",
             "bob",
@@ -1263,7 +1255,7 @@ async fn test_concurrent_migrations_dont_deadlock() {
             let store = MySQLDataStore::from_config(&config).await?;
             store.run_migrations().await?;
 
-            eprintln!("Migration instance {} completed", i);
+            eprintln!("Migration instance {i} completed");
             Ok::<_, StorageError>(())
         }));
     }
@@ -1288,11 +1280,11 @@ async fn test_concurrent_migrations_dont_deadlock() {
             Ok(Ok(())) => success_count += 1,
             Ok(Err(e)) => {
                 // Migration errors are acceptable (e.g., if table already exists)
-                eprintln!("Migration error (acceptable): {}", e);
+                eprintln!("Migration error (acceptable): {e}");
                 success_count += 1; // Still counts as completing without deadlock
             }
             Err(e) => {
-                panic!("Task join error: {}", e);
+                panic!("Task join error: {e}");
             }
         }
     }
@@ -1425,8 +1417,7 @@ async fn test_health_check_latency_measurement() {
     for latency in &latencies {
         assert!(
             latency.as_millis() < 1000,
-            "Latency should be under 1 second for local DB, got {:?}",
-            latency
+            "Latency should be under 1 second for local DB, got {latency:?}"
         );
     }
 }
@@ -1488,10 +1479,10 @@ async fn test_health_check_with_active_connections() {
         for i in 0..5 {
             let tuple = StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
-                format!("user{}", i),
+                format!("user{i}"),
                 None,
             );
             store_clone
@@ -1876,7 +1867,7 @@ async fn test_exactly_batch_size_tuples() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 format!("user{}", i % 100),
@@ -1916,7 +1907,7 @@ async fn test_batch_size_plus_one_tuples() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 format!("user{}", i % 100),
@@ -2093,7 +2084,7 @@ async fn test_pagination_exactly_page_size() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{:02}", i),
+                format!("doc{i:02}"),
                 "viewer",
                 "user",
                 "alice",
@@ -2159,7 +2150,7 @@ async fn test_continuation_token_at_end() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 "alice",
@@ -2242,7 +2233,7 @@ async fn test_invalid_continuation_token() {
         .map(|i| {
             StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
                 "alice",

--- a/crates/rsfga-storage/tests/postgres_integration.rs
+++ b/crates/rsfga-storage/tests/postgres_integration.rs
@@ -300,10 +300,10 @@ async fn test_connection_pool_limits() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -374,10 +374,10 @@ async fn test_concurrent_writes_isolation() {
         handles.push(tokio::spawn(async move {
             let tuple = StoredTuple {
                 object_type: "document".to_string(),
-                object_id: format!("doc{}", i),
+                object_id: format!("doc{i}"),
                 relation: "viewer".to_string(),
                 user_type: "user".to_string(),
-                user_id: format!("user{}", i),
+                user_id: format!("user{i}"),
                 user_relation: None,
                 condition_name: None,
                 condition_context: None,
@@ -427,25 +427,21 @@ async fn test_indexes_created() {
     // Check for our custom indexes
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_store")),
-        "Missing store index. Found: {:?}",
-        index_names
+        "Missing store index. Found: {index_names:?}"
     );
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_object")),
-        "Missing object index. Found: {:?}",
-        index_names
+        "Missing object index. Found: {index_names:?}"
     );
     assert!(
         index_names.iter().any(|n| n.contains("idx_tuples_user")),
-        "Missing user index. Found: {:?}",
-        index_names
+        "Missing user index. Found: {index_names:?}"
     );
     assert!(
         index_names
             .iter()
             .any(|n| n.contains("idx_tuples_relation")),
-        "Missing relation index. Found: {:?}",
-        index_names
+        "Missing relation index. Found: {index_names:?}"
     );
 }
 
@@ -464,10 +460,10 @@ async fn test_large_result_set_ordering() {
     for i in 0..100 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{:03}", i),
+            object_id: format!("doc{i:03}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
-            user_id: format!("user{:03}", i),
+            user_id: format!("user{i:03}"),
             user_relation: None,
             condition_name: None,
             condition_context: None,
@@ -758,8 +754,7 @@ async fn test_postgres_store_condition_conflict_on_different_condition() {
     // Should return ConditionConflict error (409 Conflict in OpenFGA)
     assert!(
         matches!(result, Err(StorageError::ConditionConflict(_))),
-        "Expected ConditionConflict error, got: {:?}",
-        result
+        "Expected ConditionConflict error, got: {result:?}"
     );
 
     // Original tuple should still exist with no condition
@@ -837,7 +832,7 @@ async fn test_postgres_store_rejects_oversized_condition_context() {
     // Each entry is ~100 bytes, need ~650 entries for 65KB
     for i in 0..700 {
         large_context.insert(
-            format!("key_{:04}", i),
+            format!("key_{i:04}"),
             serde_json::json!(format!(
                 "value_{:04}_padding_to_make_it_larger_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
                 i
@@ -861,8 +856,7 @@ async fn test_postgres_store_rejects_oversized_condition_context() {
     // Should return InvalidInput error due to size limit
     assert!(
         matches!(result, Err(StorageError::InvalidInput { .. })),
-        "Expected InvalidInput error for oversized condition_context, got: {:?}",
-        result
+        "Expected InvalidInput error for oversized condition_context, got: {result:?}"
     );
 
     // Cleanup
@@ -900,10 +894,10 @@ async fn test_postgres_store_pagination_with_conditions() {
 
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{:02}", i),
+            object_id: format!("doc{i:02}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
-            user_id: format!("user{:02}", i),
+            user_id: format!("user{i:02}"),
             user_relation: None,
             condition_name: condition,
             condition_context: context,
@@ -940,8 +934,7 @@ async fn test_postgres_store_pagination_with_conditions() {
                 // Tuples with conditions should have both name and context preserved
                 assert!(
                     name == "time_bound" || name == "ip_check",
-                    "Expected known condition name, got: {}",
-                    name
+                    "Expected known condition name, got: {name}"
                 );
                 assert!(
                     ctx.contains_key("index"),
@@ -952,10 +945,7 @@ async fn test_postgres_store_pagination_with_conditions() {
                 // Tuples without conditions should have neither name nor context
             }
             (Some(name), None) => {
-                panic!(
-                    "Test data invariant violated: condition_name '{}' should have context",
-                    name
-                );
+                panic!("Test data invariant violated: condition_name '{name}' should have context");
             }
             (None, Some(_)) => {
                 panic!("Test data invariant violated: condition_context without condition_name");
@@ -1108,8 +1098,7 @@ async fn test_health_check_latency_measurement() {
     for latency in &latencies {
         assert!(
             latency.as_millis() < 1000,
-            "Latency should be under 1 second for local DB, got {:?}",
-            latency
+            "Latency should be under 1 second for local DB, got {latency:?}"
         );
     }
 }
@@ -1299,10 +1288,10 @@ async fn test_health_check_with_active_connections() {
         for i in 0..5 {
             let tuple = StoredTuple::new(
                 "document",
-                format!("doc{}", i),
+                format!("doc{i}"),
                 "viewer",
                 "user",
-                format!("user{}", i),
+                format!("user{i}"),
                 None,
             );
             store_clone

--- a/crates/rsfga-storage/tests/storage_integration.rs
+++ b/crates/rsfga-storage/tests/storage_integration.rs
@@ -325,7 +325,7 @@ async fn test_large_dataset_performance_memory() {
     for i in 0..10_000 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{}", i),
+            object_id: format!("doc{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("user{}", i % 100), // 100 unique users
@@ -405,7 +405,7 @@ async fn test_large_dataset_performance_postgres() {
     for i in 0..10_000 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{}", i),
+            object_id: format!("doc{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("user{}", i % 100), // 100 unique users
@@ -486,7 +486,7 @@ async fn test_large_dataset_performance_mysql() {
     for i in 0..10_000 {
         tuples.push(StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{}", i),
+            object_id: format!("doc{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
             user_id: format!("user{}", i % 100), // 100 unique users
@@ -682,10 +682,10 @@ async fn test_concurrent_access_across_threads() {
             for j in 0..100 {
                 let tuple = StoredTuple {
                     object_type: "doc".to_string(),
-                    object_id: format!("doc-{}-{}", i, j),
+                    object_id: format!("doc-{i}-{j}"),
                     relation: "viewer".to_string(),
                     user_type: "user".to_string(),
-                    user_id: format!("user-{}", i),
+                    user_id: format!("user-{i}"),
                     user_relation: None,
                     condition_name: None,
                     condition_context: None,
@@ -729,10 +729,10 @@ async fn run_pagination_test<S: DataStore>(store: &S, store_id: &str) {
     let tuples: Vec<StoredTuple> = (0..25)
         .map(|i| StoredTuple {
             object_type: "document".to_string(),
-            object_id: format!("doc{}", i),
+            object_id: format!("doc{i}"),
             relation: "viewer".to_string(),
             user_type: "user".to_string(),
-            user_id: format!("user{}", i),
+            user_id: format!("user{i}"),
             user_relation: None,
             condition_name: None,
             condition_context: None,
@@ -843,7 +843,7 @@ async fn run_update_store_not_found_test<S: DataStore>(store: &S) {
         StorageError::StoreNotFound { store_id } => {
             assert_eq!(store_id, "non-existent-store-id");
         }
-        e => panic!("Expected StoreNotFound, got {:?}", e),
+        e => panic!("Expected StoreNotFound, got {e:?}"),
     }
 }
 
@@ -947,7 +947,7 @@ async fn test_update_store_concurrent_memory() {
         let store_id = store_id.to_string();
         handles.push(tokio::spawn(async move {
             store
-                .update_store(&store_id, &format!("Name from task {}", i))
+                .update_store(&store_id, &format!("Name from task {i}"))
                 .await
         }));
     }
@@ -955,7 +955,7 @@ async fn test_update_store_concurrent_memory() {
     // All updates should succeed (no panics or errors)
     for handle in handles {
         let result = handle.await.unwrap();
-        assert!(result.is_ok(), "Concurrent update failed: {:?}", result);
+        assert!(result.is_ok(), "Concurrent update failed: {result:?}");
     }
 
     // Verify the store has some valid name (one of the updates won)
@@ -980,11 +980,10 @@ async fn test_update_store_validates_store_id() {
         StorageError::InvalidInput { message } => {
             assert!(
                 message.contains("store_id"),
-                "Error message should mention store_id: {}",
-                message
+                "Error message should mention store_id: {message}"
             );
         }
-        e => panic!("Expected InvalidInput, got {:?}", e),
+        e => panic!("Expected InvalidInput, got {e:?}"),
     }
 
     // Store id with only whitespace should fail
@@ -1009,11 +1008,10 @@ async fn test_update_store_validates_name() {
         StorageError::InvalidInput { message } => {
             assert!(
                 message.contains("name"),
-                "Error message should mention name: {}",
-                message
+                "Error message should mention name: {message}"
             );
         }
-        e => panic!("Expected InvalidInput, got {:?}", e),
+        e => panic!("Expected InvalidInput, got {e:?}"),
     }
 
     // Clean up
@@ -1034,11 +1032,10 @@ async fn test_update_store_rejects_long_store_id() {
         StorageError::InvalidInput { message } => {
             assert!(
                 message.contains("store_id") && message.contains("maximum length"),
-                "Error message should mention store_id and maximum length: {}",
-                message
+                "Error message should mention store_id and maximum length: {message}"
             );
         }
-        e => panic!("Expected InvalidInput, got {:?}", e),
+        e => panic!("Expected InvalidInput, got {e:?}"),
     }
 }
 
@@ -1059,11 +1056,10 @@ async fn test_update_store_rejects_long_name() {
         StorageError::InvalidInput { message } => {
             assert!(
                 message.contains("name") && message.contains("maximum length"),
-                "Error message should mention name and maximum length: {}",
-                message
+                "Error message should mention name and maximum length: {message}"
             );
         }
-        e => panic!("Expected InvalidInput, got {:?}", e),
+        e => panic!("Expected InvalidInput, got {e:?}"),
     }
 
     // Clean up

--- a/crates/rsfga-storage/tests/testcontainers_integration.rs
+++ b/crates/rsfga-storage/tests/testcontainers_integration.rs
@@ -54,10 +54,8 @@ impl PostgresContainer {
     async fn new() -> Self {
         let container = Postgres::default().start().await.unwrap();
         let host_port = container.get_host_port_ipv4(5432).await.unwrap();
-        let connection_string = format!(
-            "postgres://postgres:postgres@127.0.0.1:{}/postgres",
-            host_port
-        );
+        let connection_string =
+            format!("postgres://postgres:postgres@127.0.0.1:{host_port}/postgres");
         Self {
             container,
             connection_string,
@@ -81,7 +79,7 @@ impl MysqlContainer {
         let container = Mysql::default().start().await.unwrap();
         let host_port = container.get_host_port_ipv4(3306).await.unwrap();
         // Default MySQL image uses root with no password
-        let connection_string = format!("mysql://root@127.0.0.1:{}/test", host_port);
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
         Self {
             container,
             connection_string,
@@ -447,12 +445,12 @@ async fn test_postgres_health_check_under_pool_exhaustion() {
         }
         Ok(Err(e)) => {
             // Error is acceptable under pool exhaustion
-            println!("Health check error (acceptable): {:?}", e);
+            println!("Health check error (acceptable): {e:?}");
         }
         Err(_) => {
             // Timeout is acceptable under pool exhaustion
             let elapsed = start.elapsed();
-            println!("Health check timed out after {:?} (acceptable)", elapsed);
+            println!("Health check timed out after {elapsed:?} (acceptable)");
         }
     }
 
@@ -506,12 +504,12 @@ async fn test_mysql_health_check_under_pool_exhaustion() {
         }
         Ok(Err(e)) => {
             // Error is acceptable under pool exhaustion
-            println!("Health check error (acceptable): {:?}", e);
+            println!("Health check error (acceptable): {e:?}");
         }
         Err(_) => {
             // Timeout is acceptable under pool exhaustion
             let elapsed = start.elapsed();
-            println!("Health check timed out after {:?} (acceptable)", elapsed);
+            println!("Health check timed out after {elapsed:?} (acceptable)");
         }
     }
 
@@ -603,8 +601,7 @@ async fn test_postgres_query_timeout_triggers_on_slow_query() {
     // Assert that we received a query timeout error
     assert!(
         matches!(result, Err(StorageError::QueryTimeout { .. })),
-        "Expected a QueryTimeout error, but got {:?}",
-        result
+        "Expected a QueryTimeout error, but got {result:?}"
     );
 
     // Cleanup: rollback the transaction to release the lock
@@ -642,8 +639,7 @@ async fn test_mysql_query_timeout_triggers_on_slow_query() {
     // Assert that we received a query timeout error
     assert!(
         matches!(result, Err(StorageError::QueryTimeout { .. })),
-        "Expected a QueryTimeout error, but got {:?}",
-        result
+        "Expected a QueryTimeout error, but got {result:?}"
     );
 
     // Cleanup: unlock tables
@@ -683,7 +679,7 @@ async fn test_postgres_multiple_timeouts_dont_exhaust_pool() {
             let store = Arc::clone(&store);
             tokio::spawn(async move {
                 let tuple =
-                    StoredTuple::new("doc", format!("doc{}", i), "viewer", "user", "alice", None);
+                    StoredTuple::new("doc", format!("doc{i}"), "viewer", "user", "alice", None);
                 // This should time out
                 store.write_tuple("test-timeout-recovery", tuple).await
             })
@@ -695,8 +691,7 @@ async fn test_postgres_multiple_timeouts_dont_exhaust_pool() {
         let result = handle.await.unwrap();
         assert!(
             matches!(result, Err(StorageError::QueryTimeout { .. })),
-            "Expected QueryTimeout, got {:?}",
-            result
+            "Expected QueryTimeout, got {result:?}"
         );
     }
 
@@ -715,8 +710,7 @@ async fn test_postgres_multiple_timeouts_dont_exhaust_pool() {
 
     assert!(
         result.is_ok(),
-        "Write should succeed after timeout recovery: {:?}",
-        result
+        "Write should succeed after timeout recovery: {result:?}"
     );
 
     // Cleanup
@@ -749,7 +743,7 @@ async fn test_mysql_multiple_timeouts_dont_exhaust_pool() {
             let store = Arc::clone(&store);
             tokio::spawn(async move {
                 let tuple =
-                    StoredTuple::new("doc", format!("doc{}", i), "viewer", "user", "alice", None);
+                    StoredTuple::new("doc", format!("doc{i}"), "viewer", "user", "alice", None);
                 // This should time out
                 store.write_tuple("test-timeout-recovery", tuple).await
             })
@@ -761,8 +755,7 @@ async fn test_mysql_multiple_timeouts_dont_exhaust_pool() {
         let result = handle.await.unwrap();
         assert!(
             matches!(result, Err(StorageError::QueryTimeout { .. })),
-            "Expected QueryTimeout, got {:?}",
-            result
+            "Expected QueryTimeout, got {result:?}"
         );
     }
 
@@ -781,8 +774,7 @@ async fn test_mysql_multiple_timeouts_dont_exhaust_pool() {
 
     assert!(
         result.is_ok(),
-        "Write should succeed after timeout recovery: {:?}",
-        result
+        "Write should succeed after timeout recovery: {result:?}"
     );
 
     // Cleanup
@@ -825,15 +817,13 @@ async fn test_postgres_timeout_returns_promptly() {
     // We allow a small buffer for test environment variance.
     assert!(
         elapsed.as_millis() < 3000,
-        "Operation should have returned promptly after the 1s timeout, but it took {:?}",
-        elapsed
+        "Operation should have returned promptly after the 1s timeout, but it took {elapsed:?}"
     );
 
     // Assert that the result is a timeout error
     assert!(
         matches!(result, Err(StorageError::QueryTimeout { .. })),
-        "Expected a QueryTimeout error, but got {:?}",
-        result
+        "Expected a QueryTimeout error, but got {result:?}"
     );
 
     // Cleanup
@@ -874,15 +864,13 @@ async fn test_mysql_timeout_returns_promptly() {
     // We allow a small buffer for test environment variance.
     assert!(
         elapsed.as_millis() < 3000,
-        "Operation should have returned promptly after the 1s timeout, but it took {:?}",
-        elapsed
+        "Operation should have returned promptly after the 1s timeout, but it took {elapsed:?}"
     );
 
     // Assert that the result is a timeout error
     assert!(
         matches!(result, Err(StorageError::QueryTimeout { .. })),
-        "Expected a QueryTimeout error, but got {:?}",
-        result
+        "Expected a QueryTimeout error, but got {result:?}"
     );
 
     // Cleanup
@@ -916,10 +904,10 @@ async fn test_postgres_concurrent_operations_with_container() {
             tokio::spawn(async move {
                 let tuple = StoredTuple::new(
                     "document",
-                    format!("doc{}", i),
+                    format!("doc{i}"),
                     "viewer",
                     "user",
-                    format!("user{}", i),
+                    format!("user{i}"),
                     None,
                 );
                 store.write_tuple("test-concurrent", tuple).await
@@ -962,10 +950,10 @@ async fn test_mysql_concurrent_operations_with_container() {
             tokio::spawn(async move {
                 let tuple = StoredTuple::new(
                     "document",
-                    format!("doc{}", i),
+                    format!("doc{i}"),
                     "viewer",
                     "user",
-                    format!("user{}", i),
+                    format!("user{i}"),
                     None,
                 );
                 store.write_tuple("test-concurrent", tuple).await

--- a/crates/rsfga-storage/tests/tidb_integration.rs
+++ b/crates/rsfga-storage/tests/tidb_integration.rs
@@ -111,7 +111,7 @@ impl TiDbContainer {
 
         // TiDB defaults to root user with no password
         // Need to create test database
-        let connection_string = format!("mysql://root@127.0.0.1:{}/test", host_port);
+        let connection_string = format!("mysql://root@127.0.0.1:{host_port}/test");
 
         // Wait a bit more for TiDB to fully initialize
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
@@ -387,7 +387,7 @@ async fn testcontainers_tidb_pagination() {
     for i in 0..10 {
         let tuple = StoredTuple::new(
             "document",
-            format!("doc{}", i),
+            format!("doc{i}"),
             "viewer",
             "user",
             "alice",
@@ -431,9 +431,9 @@ async fn testcontainers_tidb_autoincrement_behavior() {
 
     // Create multiple stores to test AUTO_INCREMENT
     for i in 0..5 {
-        let store_id = format!("tidb-autoinc-{}", i);
+        let store_id = format!("tidb-autoinc-{i}");
         store
-            .create_store(&store_id, &format!("Test Store {}", i))
+            .create_store(&store_id, &format!("Test Store {i}"))
             .await
             .expect("Should create store");
     }
@@ -449,7 +449,7 @@ async fn testcontainers_tidb_autoincrement_behavior() {
     // Cleanup
     for i in 0..5 {
         store
-            .delete_store(&format!("tidb-autoinc-{}", i))
+            .delete_store(&format!("tidb-autoinc-{i}"))
             .await
             .unwrap();
     }
@@ -506,10 +506,10 @@ async fn test_tidb_concurrent_writes() {
         let store_id = "tidb-concurrent".to_string();
         let tuple = StoredTuple::new(
             "document",
-            format!("doc{}", i),
+            format!("doc{i}"),
             "viewer",
             "user",
-            format!("user{}", i),
+            format!("user{i}"),
             None,
         );
 


### PR DESCRIPTION
## Summary
- Auto-fixed all `format!()`, `println!()`, `panic!()`, etc. calls to use inline format arguments
- Example: `format!("{}", x)` → `format!("{x}")`
- 56 files changed, 252 net lines removed

## Root Cause
The CI uses **Rust 1.88.0** while local development uses **Rust 1.91.0**. The `clippy::uninlined_format_args` lint has different default behavior between these versions:
- In 1.88.0: Enabled by default, triggers on old-style format args
- In 1.91.0: Different lint grouping, doesn't trigger locally

## Test plan
- [x] `cargo +1.88.0 clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (local 1.91.0)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized string formatting across the codebase to consistently use named/interpolated placeholders instead of positional ones, improving code readability and maintainability. This includes error messages, test assertions, and logging statements throughout the compatibility test suite and core library implementations.
  * No functional changes or user-facing impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->