### PR TITLE
Update release workflow to use stable Rust toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
 


### PR DESCRIPTION
## Summary
- Update `release.yml` from pinned `@1.88.0` to `@stable`
- Aligns with `ci.yml` which already uses `@stable`
- Currently stable is Rust 1.92.0

## Why
The pinned version caused lint discrepancies - `clippy::uninlined_format_args` behaves differently between Rust 1.88.0 and newer versions. Using `@stable` in both workflows ensures consistency.

## Test plan
- [x] Workflow syntax is valid
- [ ] CI passes with latest stable Rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD toolchain configuration to use the stable Rust channel instead of a fixed version, ensuring builds use current stable tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->