### PR TITLE
[BEHAVIORAL] Add CockroachDB batch operation compatibility

### DIFF
--- a/crates/rsfga-storage/src/postgres.rs
+++ b/crates/rsfga-storage/src/postgres.rs
@@ -235,8 +235,11 @@ fn build_unnest_clause(
             .map(|(i, (ty, _))| format!("UNNEST(${}{})", i + 2, ty))
             .collect::<Vec<_>>()
             .join(",\n            ");
-            
-        format!("ROWS FROM (\n            {}\n        ) AS {}({})", unnest_calls, alias, col_names)
+
+        format!(
+            "ROWS FROM (\n            {}\n        ) AS {}({})",
+            unnest_calls, alias, col_names
+        )
     } else {
         // PostgreSQL syntax: UNNEST($2..., $3...) AS alias(cols)
         let args = columns
@@ -245,7 +248,7 @@ fn build_unnest_clause(
             .map(|(i, (ty, _))| format!("${}{}", i + 2, ty))
             .collect::<Vec<_>>()
             .join(", ");
-            
+
         format!("UNNEST({}) AS {}({})", args, alias, col_names)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `build_delete_unnest()` and `build_insert_unnest()` helper functions for CockroachDB UNNEST syntax compatibility
- Updates `write_tuples()` to detect CockroachDB and use `ROWS FROM (UNNEST(...), UNNEST(...))` syntax instead of PostgreSQL's `UNNEST(..., ...)` syntax
- Adds unit tests for the UNNEST helper functions

## Background

CockroachDB uses a different UNNEST syntax than PostgreSQL for batch operations:
- **PostgreSQL**: `UNNEST($1::text[], $2::text[], ...) AS t(col1, col2, ...)`
- **CockroachDB**: `ROWS FROM (UNNEST($1::text[]), UNNEST($2::text[]), ...) AS t(...)`

The `is_cockroachdb()` detection method was already present in main but wasn't being used in `write_tuples()`. This change wires it up.

## Test plan

- [x] Unit tests for `build_delete_unnest()` (PostgreSQL and CockroachDB modes)
- [x] Unit tests for `build_insert_unnest()` (PostgreSQL and CockroachDB modes)
- [x] Unit test for custom alias in `build_insert_unnest()`
- [x] All existing storage tests pass
- [ ] Manual testing with CockroachDB container (existing `cockroachdb_integration.rs` tests)

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch write operations now automatically select the correct UNNEST vs ROWS FROM syntax for CockroachDB and PostgreSQL, improving cross‑DB reliability and performance.
* **Tests**
  * Added tests covering dialect-specific SQL generation and alias handling for batch delete/insert flows, ensuring consistent behavior across databases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->