### PR TITLE
Fix GitHub issue 213

### DIFF
--- a/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
+++ b/crates/compatibility-tests/tests/test_section_22_grpc_parity.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 
 /// Generate a unique test name suffix to prevent collisions during parallel test execution
 fn unique_name(prefix: &str) -> String {
-    format!("{}-{}", prefix, Uuid::new_v4().to_string()[..8].to_string())
+    let uuid = Uuid::new_v4().to_string();
+    format!("{}-{}", prefix, &uuid[..8])
 }
 
 // ============================================================================


### PR DESCRIPTION
Add comprehensive parity tests verifying identical behavior between gRPC and REST APIs for all OpenFGA endpoints. Previously only 10 endpoints had parity tests; this completes coverage for all 18 endpoints.

New parity tests added:
- ListStores (GET /stores vs gRPC ListStores)
- UpdateStore (gRPC UpdateStore verification)
- WriteAuthorizationModel (POST vs gRPC WriteAuthorizationModel)
- ReadAuthorizationModel (GET vs gRPC ReadAuthorizationModel)
- ListAuthorizationModels (GET vs gRPC ReadAuthorizationModels)
- ReadChanges (GET /changes vs gRPC ReadChanges)
- WriteAssertions (PUT vs gRPC WriteAssertions)
- ReadAssertions (GET vs gRPC ReadAssertions)

Each test verifies:
- Response structure matches across protocols
- Field values are identical
- Both protocols can read data written by the other

Also adds PUT and PATCH support to rest_call_raw helper function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded compatibility suite with parallel-safe test names and added PUT/PATCH support to exercise more REST operations.
  * Replaced legacy error-mapping checks with a broad gRPC↔REST parity suite covering listing, creating, updating, reading, change feeds, expansions, batch checks, and assertion workflows.
  * Added extensive error-parity validations (missing resources, invalid inputs), pagination/continuation token checks, and cross-protocol structural comparisons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->