### PR TITLE
Fix GitHub issue 209

### DIFF
--- a/crates/rsfga-api/tests/observability_integration_tests.rs
+++ b/crates/rsfga-api/tests/observability_integration_tests.rs
@@ -16,6 +16,7 @@ use axum::{
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tower::ServiceExt;
+use uuid::Uuid;
 
 use rsfga_api::http::{create_router, create_router_with_observability, AppState};
 use rsfga_api::middleware::{
@@ -158,7 +159,7 @@ async fn test_response_headers_include_request_id() {
     assert!(!id_str.is_empty(), "Request ID should not be empty");
     // Generated IDs should be valid UUIDs
     assert!(
-        uuid::Uuid::parse_str(id_str).is_ok(),
+        Uuid::parse_str(id_str).is_ok(),
         "Generated request ID should be a valid UUID"
     );
 }


### PR DESCRIPTION
Add comprehensive integration tests for observability features:

Request ID Propagation:
- Response headers include request IDs
- Client-provided request IDs are propagated
- Error responses include request IDs
- Request IDs consistent across middleware layers
- Request IDs work with batch operations

Metrics Collection:
- Metrics collected for success requests (2xx)
- Metrics collected for client errors (4xx)
- Metrics labeled by operation type
- Prometheus endpoint returns valid format
- Metrics accumulate across requests
- Latency metrics record non-zero durations

Distributed Tracing:
- Tracing spans created for requests
- Tracing includes request ID in context
- Tracing spans for error responses

Health Endpoints:
- /health endpoint returns 200 OK
- /ready endpoint returns 200 when healthy
- Health vs readiness semantic differences
- Health endpoint includes request ID

Protocol Coverage (HTTP):
- Observability with check endpoint
- Observability with write endpoint
- Observability with expand endpoint
- Observability with list-objects endpoint
- Observability with list-users endpoint
- Full observability chain end-to-end

All 24 tests pass.

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for observability, validating request ID propagation across middleware and API endpoints (including batch and sequential requests).
  * Added coverage for metrics collection (counts, durations, per-endpoint aggregation) and distributed tracing (span creation and tracing with custom IDs).
  * Added end-to-end scenarios verifying health/readiness endpoints and the full observability chain across multiple API operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->