### PR TITLE
Add assertion cleanup for store and model deletion (fixes #237)

### DIFF
--- a/crates/rsfga-api/tests/assertion_cleanup_tests.rs
+++ b/crates/rsfga-api/tests/assertion_cleanup_tests.rs
@@ -4,7 +4,14 @@
 //! - When a store is deleted, all assertions for that store are removed
 //! - When an authorization model is deleted, assertions for that model are removed
 //!
-//! See: https://github.com/openfga/rsfga/issues/237
+//! # Test Design
+//!
+//! These tests use a single shared AppState per test to accurately reflect
+//! production behavior where all requests share the same in-memory state.
+//! The assertions map is accessed via Arc to verify cleanup without creating
+//! multiple AppState instances.
+//!
+//! See: https://github.com/julianshen/rsfga/issues/237
 
 mod common;
 
@@ -14,62 +21,128 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use dashmap::DashMap;
 use tower::ServiceExt;
 
-use rsfga_api::http::{create_router, AppState};
+use rsfga_api::http::{create_router, AppState, AssertionKey, StoredAssertion};
 use rsfga_storage::{DataStore, MemoryDataStore, StoredAuthorizationModel};
 
-/// Helper to make a PUT request (for write_assertions).
-async fn put_json(
-    app: axum::Router,
-    uri: &str,
-    body: serde_json::Value,
-) -> (StatusCode, serde_json::Value) {
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri(uri)
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+// ============================================================================
+// Test Helpers
+// ============================================================================
 
-    let status = response.status();
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = if body.is_empty() {
-        serde_json::json!({})
-    } else {
-        serde_json::from_slice(&body).unwrap_or_else(
-            |_| serde_json::json!({ "raw_body": String::from_utf8_lossy(&body).to_string() }),
-        )
-    };
-    (status, json)
+/// Test context holding shared state for assertion cleanup tests.
+///
+/// This ensures all requests in a test share the same AppState, accurately
+/// reflecting production behavior.
+struct TestContext {
+    storage: Arc<MemoryDataStore>,
+    assertions: Arc<DashMap<AssertionKey, Vec<StoredAssertion>>>,
+    router: axum::Router,
 }
 
-/// Helper to make a DELETE request.
-async fn delete_request(app: axum::Router, uri: &str) -> StatusCode {
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("DELETE")
-                .uri(uri)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+impl TestContext {
+    /// Create a new test context with fresh storage and state.
+    fn new() -> Self {
+        let storage = Arc::new(MemoryDataStore::new());
+        let state = AppState::new(Arc::clone(&storage));
+        let assertions = Arc::clone(&state.assertions);
+        let router = create_router(state);
 
-    response.status()
-}
+        Self {
+            storage,
+            assertions,
+            router,
+        }
+    }
 
-/// Create a test app returning AppState for inspection.
-fn create_test_state(storage: Arc<MemoryDataStore>) -> AppState<MemoryDataStore> {
-    AppState::new(storage)
+    /// Make a PUT request (for write_assertions).
+    ///
+    /// Note: We clone the router for each request. The cloned router shares
+    /// the same underlying state (storage, assertions via Arc), so this
+    /// accurately reflects production behavior.
+    async fn put_json(
+        &self,
+        uri: &str,
+        body: serde_json::Value,
+    ) -> (StatusCode, serde_json::Value) {
+        let request = Request::builder()
+            .method("PUT")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let response = self.router.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = if body.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_slice(&body).unwrap_or_else(
+                |_| serde_json::json!({ "raw_body": String::from_utf8_lossy(&body).to_string() }),
+            )
+        };
+        (status, json)
+    }
+
+    /// Make a DELETE request.
+    async fn delete(&self, uri: &str) -> StatusCode {
+        let request = Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = self.router.clone().oneshot(request).await.unwrap();
+        response.status()
+    }
+
+    /// Create a store in storage.
+    async fn create_store(&self, store_id: &str, name: &str) {
+        self.storage.create_store(store_id, name).await.unwrap();
+    }
+
+    /// Create an authorization model in storage.
+    async fn create_model(&self, model_id: &str, store_id: &str) {
+        let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
+        let model =
+            StoredAuthorizationModel::new(model_id.to_string(), store_id, "1.1", model_json);
+        self.storage.write_authorization_model(model).await.unwrap();
+    }
+
+    /// Write a test assertion for a model.
+    async fn write_assertion(&self, store_id: &str, model_id: &str, user: &str) {
+        let (status, _) = self
+            .put_json(
+                &format!("/stores/{store_id}/assertions/{model_id}"),
+                serde_json::json!({
+                    "assertions": [{
+                        "tuple_key": {
+                            "user": user,
+                            "relation": "viewer",
+                            "object": "document:readme"
+                        },
+                        "expectation": true
+                    }]
+                }),
+            )
+            .await;
+        assert_eq!(status, StatusCode::OK, "Failed to write assertion");
+    }
+
+    /// Get the number of assertion entries.
+    fn assertion_count(&self) -> usize {
+        self.assertions.len()
+    }
+
+    /// Check if an assertion key exists.
+    fn has_assertion(&self, store_id: &str, model_id: &str) -> bool {
+        self.assertions
+            .contains_key(&(store_id.to_string(), model_id.to_string()))
+    }
 }
 
 // ============================================================================
@@ -79,241 +152,76 @@ fn create_test_state(storage: Arc<MemoryDataStore>) -> AppState<MemoryDataStore>
 /// Test that deleting a store cleans up all associated assertions.
 #[tokio::test]
 async fn test_delete_store_cleans_up_assertions() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
+    // Setup: Create store, model, and assertion
+    ctx.create_store("test-store", "Test Store").await;
+    ctx.create_model("model-1", "test-store").await;
+    ctx.write_assertion("test-store", "model-1", "user:alice")
+        .await;
 
-    // Create an authorization model
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model =
-        StoredAuthorizationModel::new("model-1".to_string(), "test-store", "1.1", model_json);
-    storage.write_authorization_model(model).await.unwrap();
+    // Verify assertion exists
+    assert_eq!(ctx.assertion_count(), 1);
+    assert!(ctx.has_assertion("test-store", "model-1"));
 
-    // Create state and app
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
-
-    // Write assertions
-    let app = create_router(state);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-1",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:alice",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": true
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-
-    // Verify assertions exist
-    assert_eq!(assertions.len(), 1);
-    assert!(assertions.contains_key(&("test-store".to_string(), "model-1".to_string())));
-
-    // Create new state sharing the same assertions map and delete the store
-    let state2 = AppState::new(Arc::clone(&storage));
-    // Copy the assertions to the new state for sharing
-    for entry in assertions.iter() {
-        state2
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions2 = Arc::clone(&state2.assertions);
-
-    let app = create_router(state2);
-    let status = delete_request(app, "/stores/test-store").await;
+    // Delete the store
+    let status = ctx.delete("/stores/test-store").await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify assertions are cleaned up
-    assert_eq!(assertions2.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 }
 
 /// Test that deleting a store cleans up assertions for multiple models.
 #[tokio::test]
 async fn test_delete_store_cleans_up_multiple_model_assertions() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
-
-    // Create two authorization models
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model1 =
-        StoredAuthorizationModel::new("model-1".to_string(), "test-store", "1.1", model_json);
-    let model2 =
-        StoredAuthorizationModel::new("model-2".to_string(), "test-store", "1.1", model_json);
-    storage.write_authorization_model(model1).await.unwrap();
-    storage.write_authorization_model(model2).await.unwrap();
-
-    // Create state
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
-
-    // Write assertions for model-1
-    let app = create_router(state);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-1",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:alice",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": true
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-
-    // Write assertions for model-2 (need to create new state sharing assertions)
-    let state2 = AppState::new(Arc::clone(&storage));
-    for entry in assertions.iter() {
-        state2
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions2 = Arc::clone(&state2.assertions);
-
-    let app = create_router(state2);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-2",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:bob",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": false
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
+    // Setup: Create store with two models and assertions
+    ctx.create_store("test-store", "Test Store").await;
+    ctx.create_model("model-1", "test-store").await;
+    ctx.create_model("model-2", "test-store").await;
+    ctx.write_assertion("test-store", "model-1", "user:alice")
+        .await;
+    ctx.write_assertion("test-store", "model-2", "user:bob")
+        .await;
 
     // Verify both assertions exist
-    assert_eq!(assertions2.len(), 2);
+    assert_eq!(ctx.assertion_count(), 2);
 
     // Delete the store
-    let state3 = AppState::new(Arc::clone(&storage));
-    for entry in assertions2.iter() {
-        state3
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions3 = Arc::clone(&state3.assertions);
-
-    let app = create_router(state3);
-    let status = delete_request(app, "/stores/test-store").await;
+    let status = ctx.delete("/stores/test-store").await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify all assertions are cleaned up
-    assert_eq!(assertions3.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 }
 
 /// Test that deleting one store doesn't affect assertions from other stores.
 #[tokio::test]
 async fn test_delete_store_preserves_other_store_assertions() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create two stores
-    storage.create_store("store-1", "Store 1").await.unwrap();
-    storage.create_store("store-2", "Store 2").await.unwrap();
-
-    // Create authorization models in both stores
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model1 = StoredAuthorizationModel::new("model-a".to_string(), "store-1", "1.1", model_json);
-    let model2 = StoredAuthorizationModel::new("model-b".to_string(), "store-2", "1.1", model_json);
-    storage.write_authorization_model(model1).await.unwrap();
-    storage.write_authorization_model(model2).await.unwrap();
-
-    // Create state
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
-
-    // Write assertions for store-1
-    let app = create_router(state);
-    let (status, _) = put_json(
-        app,
-        "/stores/store-1/assertions/model-a",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:alice",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": true
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-
-    // Write assertions for store-2
-    let state2 = AppState::new(Arc::clone(&storage));
-    for entry in assertions.iter() {
-        state2
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions2 = Arc::clone(&state2.assertions);
-
-    let app = create_router(state2);
-    let (status, _) = put_json(
-        app,
-        "/stores/store-2/assertions/model-b",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:bob",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": false
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
+    // Setup: Create two stores with assertions
+    ctx.create_store("store-1", "Store 1").await;
+    ctx.create_store("store-2", "Store 2").await;
+    ctx.create_model("model-a", "store-1").await;
+    ctx.create_model("model-b", "store-2").await;
+    ctx.write_assertion("store-1", "model-a", "user:alice")
+        .await;
+    ctx.write_assertion("store-2", "model-b", "user:bob").await;
 
     // Verify both assertions exist
-    assert_eq!(assertions2.len(), 2);
+    assert_eq!(ctx.assertion_count(), 2);
 
     // Delete store-1
-    let state3 = AppState::new(Arc::clone(&storage));
-    for entry in assertions2.iter() {
-        state3
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions3 = Arc::clone(&state3.assertions);
-
-    let app = create_router(state3);
-    let status = delete_request(app, "/stores/store-1").await;
+    let status = ctx.delete("/stores/store-1").await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify only store-1 assertions are removed
-    assert_eq!(assertions3.len(), 1);
-    assert!(!assertions3.contains_key(&("store-1".to_string(), "model-a".to_string())));
-    assert!(assertions3.contains_key(&("store-2".to_string(), "model-b".to_string())));
+    assert_eq!(ctx.assertion_count(), 1);
+    assert!(!ctx.has_assertion("store-1", "model-a"));
+    assert!(ctx.has_assertion("store-2", "model-b"));
 }
 
 // ============================================================================
@@ -323,184 +231,80 @@ async fn test_delete_store_preserves_other_store_assertions() {
 /// Test that deleting an authorization model cleans up its assertions.
 #[tokio::test]
 async fn test_delete_authorization_model_cleans_up_assertions() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
+    // Setup: Create store, model, and assertion
+    ctx.create_store("test-store", "Test Store").await;
+    ctx.create_model("model-1", "test-store").await;
+    ctx.write_assertion("test-store", "model-1", "user:alice")
+        .await;
 
-    // Create an authorization model
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model =
-        StoredAuthorizationModel::new("model-1".to_string(), "test-store", "1.1", model_json);
-    storage.write_authorization_model(model).await.unwrap();
-
-    // Create state
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
-
-    // Write assertions
-    let app = create_router(state);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-1",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:alice",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": true
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-
-    // Verify assertions exist
-    assert_eq!(assertions.len(), 1);
+    // Verify assertion exists
+    assert_eq!(ctx.assertion_count(), 1);
 
     // Delete the authorization model
-    let state2 = AppState::new(Arc::clone(&storage));
-    for entry in assertions.iter() {
-        state2
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions2 = Arc::clone(&state2.assertions);
-
-    let app = create_router(state2);
-    let status = delete_request(app, "/stores/test-store/authorization-models/model-1").await;
+    let status = ctx
+        .delete("/stores/test-store/authorization-models/model-1")
+        .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify assertions are cleaned up
-    assert_eq!(assertions2.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 }
 
 /// Test that deleting one model doesn't affect assertions from other models.
 #[tokio::test]
 async fn test_delete_model_preserves_other_model_assertions() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
-
-    // Create two authorization models
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model1 =
-        StoredAuthorizationModel::new("model-1".to_string(), "test-store", "1.1", model_json);
-    let model2 =
-        StoredAuthorizationModel::new("model-2".to_string(), "test-store", "1.1", model_json);
-    storage.write_authorization_model(model1).await.unwrap();
-    storage.write_authorization_model(model2).await.unwrap();
-
-    // Create state
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
-
-    // Write assertions for model-1
-    let app = create_router(state);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-1",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:alice",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": true
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-
-    // Write assertions for model-2
-    let state2 = AppState::new(Arc::clone(&storage));
-    for entry in assertions.iter() {
-        state2
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions2 = Arc::clone(&state2.assertions);
-
-    let app = create_router(state2);
-    let (status, _) = put_json(
-        app,
-        "/stores/test-store/assertions/model-2",
-        serde_json::json!({
-            "assertions": [{
-                "tuple_key": {
-                    "user": "user:bob",
-                    "relation": "viewer",
-                    "object": "document:readme"
-                },
-                "expectation": false
-            }]
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
+    // Setup: Create store with two models and assertions
+    ctx.create_store("test-store", "Test Store").await;
+    ctx.create_model("model-1", "test-store").await;
+    ctx.create_model("model-2", "test-store").await;
+    ctx.write_assertion("test-store", "model-1", "user:alice")
+        .await;
+    ctx.write_assertion("test-store", "model-2", "user:bob")
+        .await;
 
     // Verify both assertions exist
-    assert_eq!(assertions2.len(), 2);
+    assert_eq!(ctx.assertion_count(), 2);
 
     // Delete model-1
-    let state3 = AppState::new(Arc::clone(&storage));
-    for entry in assertions2.iter() {
-        state3
-            .assertions
-            .insert(entry.key().clone(), entry.value().clone());
-    }
-    let assertions3 = Arc::clone(&state3.assertions);
-
-    let app = create_router(state3);
-    let status = delete_request(app, "/stores/test-store/authorization-models/model-1").await;
+    let status = ctx
+        .delete("/stores/test-store/authorization-models/model-1")
+        .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify only model-1 assertions are removed
-    assert_eq!(assertions3.len(), 1);
-    assert!(!assertions3.contains_key(&("test-store".to_string(), "model-1".to_string())));
-    assert!(assertions3.contains_key(&("test-store".to_string(), "model-2".to_string())));
+    assert_eq!(ctx.assertion_count(), 1);
+    assert!(!ctx.has_assertion("test-store", "model-1"));
+    assert!(ctx.has_assertion("test-store", "model-2"));
 }
 
 /// Test that deleting a non-existent model returns 404.
 #[tokio::test]
 async fn test_delete_nonexistent_model_returns_404() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
-
-    let state = create_test_state(storage);
-    let app = create_router(state);
+    // Setup: Create store only (no model)
+    ctx.create_store("test-store", "Test Store").await;
 
     // Try to delete a non-existent model
-    let status = delete_request(app, "/stores/test-store/authorization-models/nonexistent").await;
+    let status = ctx
+        .delete("/stores/test-store/authorization-models/nonexistent")
+        .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 /// Test that deleting a model from a non-existent store returns 404.
 #[tokio::test]
 async fn test_delete_model_from_nonexistent_store_returns_404() {
-    let storage = Arc::new(MemoryDataStore::new());
-
-    let state = create_test_state(storage);
-    let app = create_router(state);
+    let ctx = TestContext::new();
 
     // Try to delete a model from a non-existent store
-    let status = delete_request(app, "/stores/nonexistent/authorization-models/model-1").await;
+    let status = ctx
+        .delete("/stores/nonexistent/authorization-models/model-1")
+        .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
@@ -511,57 +315,40 @@ async fn test_delete_model_from_nonexistent_store_returns_404() {
 /// Test that deleting a store with no assertions succeeds.
 #[tokio::test]
 async fn test_delete_store_with_no_assertions_succeeds() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
-
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
+    // Setup: Create store only (no assertions)
+    ctx.create_store("test-store", "Test Store").await;
 
     // Verify no assertions exist
-    assert_eq!(assertions.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 
     // Delete the store
-    let app = create_router(state);
-    let status = delete_request(app, "/stores/test-store").await;
+    let status = ctx.delete("/stores/test-store").await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify still no assertions
-    assert_eq!(assertions.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 }
 
 /// Test that deleting a model with no assertions succeeds.
 #[tokio::test]
 async fn test_delete_model_with_no_assertions_succeeds() {
-    let storage = Arc::new(MemoryDataStore::new());
+    let ctx = TestContext::new();
 
-    // Create a store
-    storage
-        .create_store("test-store", "Test Store")
-        .await
-        .unwrap();
-
-    // Create an authorization model
-    let model_json = r#"{"type_definitions": [{"type": "user"}, {"type": "document", "relations": {"viewer": {"this": {}}}}]}"#;
-    let model =
-        StoredAuthorizationModel::new("model-1".to_string(), "test-store", "1.1", model_json);
-    storage.write_authorization_model(model).await.unwrap();
-
-    let state = create_test_state(Arc::clone(&storage));
-    let assertions = Arc::clone(&state.assertions);
+    // Setup: Create store and model (no assertions)
+    ctx.create_store("test-store", "Test Store").await;
+    ctx.create_model("model-1", "test-store").await;
 
     // Verify no assertions exist
-    assert_eq!(assertions.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 
     // Delete the model
-    let app = create_router(state);
-    let status = delete_request(app, "/stores/test-store/authorization-models/model-1").await;
+    let status = ctx
+        .delete("/stores/test-store/authorization-models/model-1")
+        .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     // Verify still no assertions
-    assert_eq!(assertions.len(), 0);
+    assert_eq!(ctx.assertion_count(), 0);
 }


### PR DESCRIPTION
## Summary

Implements automatic assertion cleanup when stores or authorization models are deleted, preventing orphaned assertion data from consuming memory in long-running production environments.

**Changes:**
- Add assertion cleanup to `delete_store` handler - removes all assertions for any model in the deleted store
- Add `delete_authorization_model` HTTP endpoint (DELETE /stores/:store_id/authorization-models/:model_id) with assertion cleanup
- Add comprehensive test suite (9 tests)

## Test Plan

- [x] Test: Store deletion cleans up single model assertions
- [x] Test: Store deletion cleans up multiple model assertions  
- [x] Test: Store deletion preserves assertions from other stores
- [x] Test: Model deletion cleans up its assertions
- [x] Test: Model deletion preserves other model assertions
- [x] Test: Deleting non-existent model returns 404
- [x] Test: Deleting model from non-existent store returns 404
- [x] Test: Store deletion with no assertions succeeds
- [x] Test: Model deletion with no assertions succeeds
- [x] All rsfga-api tests pass
- [x] Clippy passes with no warnings
- [x] Format check passes

## Implementation Details

The cleanup uses the DashMap's efficient iteration to find and remove assertion keys matching the deleted store or model:

```rust
// Store deletion - remove all assertions for the store
let keys_to_remove: Vec<_> = state
    .assertions
    .iter()
    .filter(|entry| entry.key().0 == store_id)
    .map(|entry| entry.key().clone())
    .collect();
for key in keys_to_remove {
    state.assertions.remove(&key);
}

// Model deletion - remove specific model's assertions
let key = (store_id, model_id);
state.assertions.remove(&key);
```

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization models can be deleted via a new DELETE endpoint.
* **Bug Fixes / Data Integrity**
  * Deleting a store or an authorization model now automatically removes its associated assertions to prevent stale data.
* **Tests**
  * Added comprehensive tests validating cleanup behavior for stores and authorization models, including edge cases and error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->