### PR TITLE
Fix Expand API response to include root wrapper (Fixes #259)

### DIFF
--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -1335,10 +1335,20 @@ pub struct ExpandRequestBody {
 }
 
 /// Response for expand operation.
+///
+/// OpenFGA returns a nested structure with `tree.root` containing the expansion.
 #[derive(Debug, Serialize)]
 pub struct ExpandResponseBody {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tree: Option<ExpandNodeBody>,
+    pub tree: Option<ExpandTreeBody>,
+}
+
+/// Tree wrapper containing the root node.
+///
+/// This matches OpenFGA's response format where the tree has a `root` property.
+#[derive(Debug, Serialize)]
+pub struct ExpandTreeBody {
+    pub root: ExpandNodeBody,
 }
 
 /// A node in the expansion tree.
@@ -1518,8 +1528,11 @@ async fn expand<S: DataStore>(
     let result = state.resolver.expand(&expand_request).await?;
 
     // Convert domain result to HTTP response
+    // Wrap the root node in ExpandTreeBody to match OpenFGA's response format
     Ok(Json(ExpandResponseBody {
-        tree: Some(expand_node_to_body(result.tree.root)),
+        tree: Some(ExpandTreeBody {
+            root: expand_node_to_body(result.tree.root),
+        }),
     }))
 }
 


### PR DESCRIPTION
## Summary

- Fix Expand API response to include the `root` wrapper in the tree structure
- Matches OpenFGA's response format: `{"tree": {"root": {...}}}`

## Root Cause

The Expand API response was missing the `root` wrapper. OpenFGA returns `tree.root` containing the expansion, but RSFGA was returning the node directly under `tree`.

## Changes

1. Added `ExpandTreeBody` struct to wrap the root node:
```rust
#[derive(Debug, Serialize)]
pub struct ExpandTreeBody {
    pub root: ExpandNodeBody,
}
```

2. Updated `ExpandResponseBody.tree` to use `ExpandTreeBody` instead of `ExpandNodeBody`

3. Updated expand handler to wrap the root node in `ExpandTreeBody`

## Before/After

Before:
```json
{"tree": {"name": "...", "leaf": {...}}}
```

After:
```json
{"tree": {"root": {"name": "...", "leaf": {...}}}}
```

## Test plan

- [x] All Section 14 tests pass (15 tests including `test_expand_returns_relation_tree`, `test_expand_shows_direct_relations_as_leaf`, `test_expand_shows_computed_relations`, etc.)
- [x] All Section 16 tests pass (including `test_complex_nested_computed_relations`)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt --check` passes
- [x] All library tests pass

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the expand response structure to align with OpenFGA compatibility standards. The tree data is now returned with an additional nesting level, changing how the response payload is organized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->