### PR TITLE
[Fix #260] List Stores API pagination

### DIFF
--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -685,6 +685,13 @@ impl From<rsfga_storage::Store> for StoreResponse {
 }
 
 /// Query parameters for listing stores.
+///
+/// # Validation Rules
+///
+/// - `page_size`: Optional. Defaults to 50. Must be positive (> 0).
+///   Values exceeding 50 are clamped to the maximum (50).
+/// - `continuation_token`: Optional. Base64-encoded token from a previous
+///   response to fetch the next page of results.
 #[derive(Debug, Deserialize)]
 pub struct ListStoresQuery {
     #[serde(default)]
@@ -694,6 +701,13 @@ pub struct ListStoresQuery {
 }
 
 /// Response for listing stores.
+///
+/// # Fields
+///
+/// - `stores`: Array of store objects in the current page.
+/// - `continuation_token`: Present when more results are available.
+///   Pass this token in the next request to fetch the next page.
+///   Format: Base64-encoded pagination state.
 #[derive(Debug, Serialize)]
 pub struct ListStoresResponse {
     pub stores: Vec<StoreResponse>,


### PR DESCRIPTION
## Summary
- Fixes issue #260: Store list pagination not working correctly
- `GET /stores?page_size=3` now returns exactly 3 stores with `continuation_token`
- Uses existing `list_stores_paginated` from storage layer
- Default page size is 50 (consistent with OpenFGA behavior)

## Changes
- Added `ListStoresQuery` struct to parse query parameters with doc comments
- Added `ListStoresResponse` struct with proper serialization and doc comments
- Updated `list_stores` handler to use pagination with validation:
  - Returns 400 Bad Request if `page_size=0`
  - Clamps `page_size` to max 50 for DoS protection
  - Default page size: 50 (matches OpenFGA)

## Test plan
- [x] All rsfga-api tests pass
- [x] Clippy clean
- [x] Verified OpenFGA uses default page_size of 50 for ListStores

## Addressed Review Feedback
- ✅ Added `page_size == 0` validation (returns 400)
- ✅ Added `page_size` max clamping (capped at 50)
- ✅ Added doc comments for `ListStoresQuery` and `ListStoresResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented paginated store listing to handle large result sets.
  * Clients can request page sizes and use continuation tokens to navigate pages.
  * Responses now include a list of stores plus an optional continuation token for fetching subsequent pages.
  * Page size is capped at a maximum to ensure stable, predictable performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->