### PR TITLE
[Fix #263] Implement proper changelog for ReadChanges API

### DIFF
--- a/crates/rsfga-api/tests/http_status_code_tests.rs
+++ b/crates/rsfga-api/tests/http_status_code_tests.rs
@@ -1124,6 +1124,18 @@ impl DataStore for MockStorage {
             message: Some("mock".to_string()),
         })
     }
+
+    async fn read_changes(
+        &self,
+        _store_id: &str,
+        _filter: &rsfga_storage::ReadChangesFilter,
+        _pagination: &PaginationOptions,
+    ) -> StorageResult<PaginatedResult<rsfga_storage::TupleChange>> {
+        Ok(PaginatedResult {
+            items: vec![],
+            continuation_token: None,
+        })
+    }
 }
 
 // Factory functions for backwards compatibility with existing tests

--- a/crates/rsfga-storage/src/lib.rs
+++ b/crates/rsfga-storage/src/lib.rs
@@ -101,8 +101,8 @@ pub use mysql::{MySQLConfig, MySQLDataStore};
 pub use postgres::{PostgresConfig, PostgresDataStore};
 pub use traits::{
     parse_continuation_token, parse_user_filter, validate_store_id, validate_store_name,
-    validate_tuple, DataStore, PaginatedResult, PaginationOptions, Store, StoredAuthorizationModel,
-    StoredTuple, TupleFilter,
+    validate_tuple, DataStore, PaginatedResult, PaginationOptions, ReadChangesFilter, Store,
+    StoredAuthorizationModel, StoredTuple, TupleChange, TupleFilter, TupleOperation,
 };
 
 // Re-export chrono types for timestamp handling


### PR DESCRIPTION
## Summary
- Adds proper changelog tracking for tuple writes and deletes
- Returns changes in chronological order (timestamp ASC, id ASC)
- Includes correct operation types (TUPLE_OPERATION_WRITE, TUPLE_OPERATION_DELETE)

## Changes
- **Storage Layer**: Added `TupleChange`, `TupleOperation`, `ReadChangesFilter` types and `read_changes` method to DataStore trait
- **MemoryDataStore**: Tracks changelog in `DashMap<String, Vec<TupleChange>>`
- **PostgresDataStore**: New `changelog` table with proper indexing for chronological queries
- **MySqlDataStore**: New `changelog` table with TIMESTAMP(6) for microsecond precision
- **HTTP/gRPC handlers**: Updated to use the new `read_changes` method

## Fixes
Closes #263

## Test plan
- [x] All read_changes related tests pass (12 tests)
- [x] Pagination tests pass
- [x] Clippy passes with no warnings
- [x] Code is formatted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change history tracking across all storage backends. Users can now query a chronological changelog of tuple modifications, including operation type (write/delete) and precise timestamps, with filtering by object type and pagination support for efficient large-scale queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->