### PR TITLE
[Fix #264] Add support for Unicode characters in identifiers

### DIFF
--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -182,6 +182,7 @@ fn storage_error_to_status(err: StorageError) -> Status {
         }
         StorageError::TupleNotFound { .. } => Status::not_found(err.to_string()),
         StorageError::InvalidInput { message } => Status::invalid_argument(message),
+        StorageError::InvalidFilter { message } => Status::invalid_argument(message),
         // ALREADY_EXISTS (6): duplicate tuple or condition conflict
         StorageError::DuplicateTuple { .. } => Status::already_exists(err.to_string()),
         StorageError::ConditionConflict(conflict) => {

--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -478,6 +478,7 @@ impl From<StorageError> for ApiError {
                     ApiError::validation_error(message)
                 }
             }
+            StorageError::InvalidFilter { message } => ApiError::validation_error(message),
             // 409 Conflict: duplicate tuple or condition conflict
             StorageError::DuplicateTuple { .. } => {
                 ApiError::conflict("cannot write a tuple which already exists")

--- a/crates/rsfga-api/src/http/tests.rs
+++ b/crates/rsfga-api/src/http/tests.rs
@@ -2048,6 +2048,17 @@ fn test_storage_error_generic_invalid_input() {
     assert_eq!(api_error.code, error_codes::VALIDATION_ERROR);
 }
 
+/// Test: StorageError::InvalidFilter maps to validation_error (400 Bad Request)
+#[test]
+fn test_storage_error_invalid_filter() {
+    let error = StorageError::InvalidFilter {
+        message: "Invalid user filter format: 'invalid'. Expected 'type:id'".to_string(),
+    };
+    let api_error: ApiError = error.into();
+    assert_eq!(api_error.code, error_codes::VALIDATION_ERROR);
+    assert!(api_error.message.contains("Invalid user filter format"));
+}
+
 /// Test: ApiError constructors produce correct error codes
 #[test]
 fn test_api_error_constructors_produce_correct_codes() {

--- a/crates/rsfga-storage/src/traits.rs
+++ b/crates/rsfga-storage/src/traits.rs
@@ -1090,4 +1090,44 @@ mod tests {
         assert_eq!(result.items.len(), 2);
         assert_eq!(result.continuation_token, Some("next-page".to_string()));
     }
+
+    // Test: parse_user_filter works with Unicode characters
+    #[test]
+    fn test_parse_user_filter_unicode() {
+        // Chinese characters
+        let (user_type, user_id, relation) = parse_user_filter("user:用户123").unwrap();
+        assert_eq!(user_type, "user");
+        assert_eq!(user_id, "用户123");
+        assert!(relation.is_none());
+
+        // Japanese characters
+        let (user_type, user_id, relation) = parse_user_filter("user:ユーザー").unwrap();
+        assert_eq!(user_type, "user");
+        assert_eq!(user_id, "ユーザー");
+        assert!(relation.is_none());
+
+        // Emoji
+        let (user_type, user_id, relation) = parse_user_filter("user:👤").unwrap();
+        assert_eq!(user_type, "user");
+        assert_eq!(user_id, "👤");
+        assert!(relation.is_none());
+
+        // Arabic characters
+        let (user_type, user_id, relation) = parse_user_filter("user:مستخدم").unwrap();
+        assert_eq!(user_type, "user");
+        assert_eq!(user_id, "مستخدم");
+        assert!(relation.is_none());
+
+        // Accented Latin characters
+        let (user_type, user_id, relation) = parse_user_filter("user:Müller").unwrap();
+        assert_eq!(user_type, "user");
+        assert_eq!(user_id, "Müller");
+        assert!(relation.is_none());
+
+        // Unicode in userset format
+        let (user_type, user_id, relation) = parse_user_filter("group:团队#成员").unwrap();
+        assert_eq!(user_type, "group");
+        assert_eq!(user_id, "团队");
+        assert_eq!(relation, Some("成员".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds proper error mapping for `StorageError::InvalidFilter` to return 400 Bad Request
- Ensures Unicode characters in user and object identifiers work correctly with the Read API

## Changes
- **HTTP layer**: Added `StorageError::InvalidFilter` handling in `From<StorageError> for ApiError` to return `validation_error` (400)
- **gRPC layer**: Added `StorageError::InvalidFilter` handling to return `Status::invalid_argument`
- **Tests**: Added Unicode test for `parse_user_filter` covering Chinese, Japanese, Emoji, Arabic, and accented Latin characters
- **Tests**: Added test verifying `InvalidFilter` maps to `validation_error`

## Root Cause
The `parse_user_filter` function already correctly handles Unicode characters (it only checks for colon separators and non-empty parts). However, `StorageError::InvalidFilter` was not explicitly handled in the error mapping, causing it to fall through to the default case returning 500 instead of 400.

## Fixes
Closes #264

## Test plan
- [x] `test_parse_user_filter_unicode` passes (verifies Unicode parsing works)
- [x] `test_storage_error_invalid_filter` passes (verifies error mapping)
- [x] All storage and API tests pass
- [x] Clippy passes with no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Invalid filter inputs now return proper validation error responses in both HTTP and gRPC APIs.

* **Tests**
  * Added verification for Unicode character support in user filter parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->