### PR TITLE
Remove store ID format validation to match OpenFGA behavior

### DIFF
--- a/crates/rsfga-api/tests/cel_condition_tests.rs
+++ b/crates/rsfga-api/tests/cel_condition_tests.rs
@@ -1541,10 +1541,10 @@ async fn test_check_nonexistent_store_returns_404() {
     );
 }
 
-/// Test: Check with invalid store ID format returns 400.
-/// OpenFGA validates store ID format before checking if the store exists.
+/// Test: Check with invalid store ID format returns 404.
+/// OpenFGA returns 404 for any non-existent store, regardless of ID format.
 #[tokio::test]
-async fn test_check_invalid_store_id_format_returns_400() {
+async fn test_check_invalid_store_id_format_returns_404() {
     let storage = Arc::new(MemoryDataStore::new());
 
     let (status, _response) = post_json(
@@ -1562,8 +1562,8 @@ async fn test_check_invalid_store_id_format_returns_400() {
 
     assert_eq!(
         status,
-        StatusCode::BAD_REQUEST,
-        "Invalid store ID format should return 400"
+        StatusCode::NOT_FOUND,
+        "Non-existent store (regardless of ID format) should return 404"
     );
 }
 

--- a/crates/rsfga-api/tests/deployment_scenario_tests.rs
+++ b/crates/rsfga-api/tests/deployment_scenario_tests.rs
@@ -1001,7 +1001,8 @@ async fn test_rest_api_consistent_error_format() {
         "Error should have 'message'"
     );
 
-    // Test 400 - bad request (invalid store ID format)
+    // Test 404 - non-existent store (regardless of ID format)
+    // OpenFGA returns 404 for any non-existent store, not 400 for invalid format
     let (status, response) = post_json(
         create_test_app(&storage),
         "/stores/invalid-store-id/check",
@@ -1015,7 +1016,7 @@ async fn test_rest_api_consistent_error_format() {
     )
     .await;
 
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::NOT_FOUND);
     assert!(response.get("code").is_some(), "Error should have 'code'");
     assert!(
         response.get("message").is_some(),


### PR DESCRIPTION
## Summary
This PR removes strict store ID format validation from the API layer to align with OpenFGA's actual behavior. OpenFGA returns 404 (not found) for any non-existent store regardless of ID format, rather than returning 400 (bad request) for invalid formats.

## Key Changes
- **Removed `validate_store_id_format()` calls** from all route handlers (get_store, update_store, delete_store, check, batch_check, expand, write_tuples, read_tuples, read_changes, write_assertions, read_assertions, list_objects, list_users, and authorization model endpoints)
- **Updated test expectations** to expect 404 instead of 400 for non-existent stores with any ID format
- **Enhanced compatibility test** (`test_all_openfga_api_endpoints_present`) to use valid ULID format for store and model IDs, and to create a proper authorization model before testing endpoints that require it
- **Updated comments** throughout to clarify that OpenFGA returns 404 for any non-existent store, regardless of ID format validation

## Implementation Details
- Store existence validation now happens naturally through storage layer operations (get_store, etc.), which return 404 when a store doesn't exist
- This simplifies the API layer and removes redundant validation logic
- The change makes the implementation more compatible with OpenFGA's actual behavior, which doesn't perform strict format validation upfront
- Test data now uses proper ULID format (generated with `ulid::Ulid::new()`) for better realism