### PR TITLE
[Fix #290] Correct condition context handling expectation

### DIFF
--- a/crates/cli-compatibility-tests/README.md
+++ b/crates/cli-compatibility-tests/README.md
@@ -114,10 +114,9 @@ tests:
 
 ## Known Behavioral Differences
 
-The following behavioral differences between RSFGA and OpenFGA are tracked:
+No known behavioral differences. RSFGA aims for 100% OpenFGA API compatibility.
 
-| Issue | Description | RSFGA Behavior | OpenFGA Behavior |
-|-------|-------------|----------------|------------------|
-| [#290](https://github.com/julianshen/rsfga/issues/290) | Missing condition context | Returns explicit error | Returns `false` |
-
-These differences are documented in the relevant test files with comments explaining the deviation.
+Note: Both RSFGA and OpenFGA return error code 2000 when required condition context
+parameters are missing from a Check request. This is correct behavior - the condition
+cannot be evaluated without its required parameters. See issue #290 for investigation
+details.

--- a/crates/cli-compatibility-tests/tests/08-conditions.fga.yaml
+++ b/crates/cli-compatibility-tests/tests/08-conditions.fga.yaml
@@ -118,8 +118,17 @@ tests:
           ip_restricted_editor: false
           editor: false
 
-  # NOTE: "Missing context" test removed - RSFGA returns an explicit error
-  # when required condition context is missing, rather than returning false.
-  # This is a behavioral difference that may need addressing for full OpenFGA
-  # compatibility. RSFGA behavior: explicit error; OpenFGA behavior: returns false
-  # Tracked in: https://github.com/julianshen/rsfga/issues/290
+  # NOTE: OpenFGA returns error code 2000 when required condition context is missing.
+  # This is intentional behavior - the Check operation cannot be evaluated without
+  # the required parameters. The fga model test framework does not support assertions
+  # that expect errors, so this test case is commented out.
+  #
+  # See: https://github.com/julianshen/rsfga/issues/290 (closed - not a bug)
+  #
+  # - name: "Missing context returns error for conditional tuples"
+  #   check:
+  #     - user: user:bob
+  #       object: document:sensitive
+  #       assertions:
+  #         time_limited_viewer: error  # Not supported by fga test framework
+  #         viewer: error


### PR DESCRIPTION
## Summary

After testing against a real OpenFGA instance, confirmed that both RSFGA and OpenFGA return error code 2000 when required condition context parameters are missing. The original issue was based on incorrect expectations.

## Changes

- **08-conditions.fga.yaml**: Comment out incorrect test that expected `false` - both implementations return error
- **README.md**: Document correct behavior (both return error, not false)
- **resolver_tests.rs**: Add unit test that verifies error is returned when context is missing

## Test Plan

- [x] All 35 condition-related unit tests pass
- [x] All 7 valid CLI compatibility tests pass (8th test was incorrect)
- [x] Verified against real OpenFGA docker container
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes

## Investigation Details

Tested the same model against OpenFGA v1.x:
```
$ FGA_API_URL=http://localhost:8081 fga model test --tests tests/08-conditions.fga.yaml
(FAILING) Missing context returns false for conditional tuples: Checks (0/4 passing)
ⅹ Check(...): error=rpc error: code = Code(2000) desc = failed to evaluate relationship condition...
```

Both implementations correctly return error code 2000 when required condition parameters are missing. This is correct behavior - conditions cannot be evaluated without their required parameters.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that RSFGA aims for 100% OpenFGA API compatibility with no known behavioral differences.
  * Added note that error code 2000 is returned when required condition context parameters are missing from Check requests.

* **Tests**
  * Enhanced test coverage for condition context handling and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->