### PR TITLE
Fix RocksDB backend validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-01-31
+
+### Fixed
+- **RocksDB backend validation** - Add "rocksdb" to valid storage backends list in config validation
+- **RocksDB data_path validation** - Add validation that data_path is required when using RocksDB backend
+
 ## [1.0.0] - 2025-01-31
 
 ### 🎉 Initial Production Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compatibility-tests"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "rsfga-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "rsfga-domain"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "rsfga-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "rsfga-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["RSFGA Contributors"]

--- a/crates/rsfga-server/src/config.rs
+++ b/crates/rsfga-server/src/config.rs
@@ -394,7 +394,7 @@ impl ServerConfig {
         }
 
         // Validate storage backend
-        let valid_backends = ["memory", "postgres", "mysql", "cockroachdb"];
+        let valid_backends = ["memory", "postgres", "mysql", "cockroachdb", "rocksdb"];
         if !valid_backends.contains(&self.storage.backend.as_str()) {
             return Err(ConfigLoadError::Invalid {
                 message: format!(
@@ -418,6 +418,19 @@ impl ServerConfig {
                     "storage.database_url is required when backend is '{}'",
                     self.storage.backend
                 ),
+            });
+        }
+
+        // Validate rocksdb backend requires non-empty data_path
+        if self.storage.backend == "rocksdb"
+            && self
+                .storage
+                .data_path
+                .as_deref()
+                .map_or(true, |s| s.trim().is_empty())
+        {
+            return Err(ConfigLoadError::Invalid {
+                message: "storage.data_path is required when backend is 'rocksdb'".to_string(),
             });
         }
 


### PR DESCRIPTION
## Summary
- Add "rocksdb" to valid storage backends list in config validation
- Add validation that data_path is required when using RocksDB backend
- Bump version to 1.0.1

## Problem
v1.0.0 Docker image fails to start with RocksDB backend because "rocksdb" was missing from the valid backends validation list.

## Test plan
- [ ] Config tests pass
- [ ] Docker image starts with RocksDB backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RocksDB as a storage backend option.

* **Bug Fixes**
  * Fixed backend validation to properly recognize RocksDB configurations.
  * Enforced data path requirement when using RocksDB backend.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->