### PR TITLE
[Milestone 1.16] ListObjects Full Resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,7 +1029,7 @@ Follow this process precisely, always prioritizing:
   - Milestone 3.1 (Benchmarking): ✅ Complete (#325, #326, #327)
   - gRPC Precompute Cache Wiring: ✅ Complete (#329)
 
-- Milestone 1.16 (ListObjects Full Resolver): 🏗️ In Progress
+- Milestone 1.16 (ListObjects Full Resolver): 📝 In Review (#331)
   - ✅ Structural refactoring (ReverseExpandContext/ReverseExpandState)
   - ✅ authorization_model_id threading
   - ✅ Contextual tuples through graph traversal
@@ -1037,6 +1037,6 @@ Follow this process precisely, always prioritizing:
   - ✅ Parallel union/intersection/exclusion branches
   - ✅ StreamedListObjects gRPC endpoint
 
-**Next Step**: Milestone 1.16 PR review and merge, then Phase 4 (Distributed Edge)
+**Next Step**: Merge Milestone 1.16 PR #331, then Phase 4 (Distributed Edge)
 
 **To continue**: Specify what you'd like to work on next!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,6 +1029,14 @@ Follow this process precisely, always prioritizing:
   - Milestone 3.1 (Benchmarking): ✅ Complete (#325, #326, #327)
   - gRPC Precompute Cache Wiring: ✅ Complete (#329)
 
-**Next Step**: Milestone 1.16 (ListObjects Full Resolver) or Phase 4 (Distributed Edge)
+- Milestone 1.16 (ListObjects Full Resolver): 🏗️ In Progress
+  - ✅ Structural refactoring (ReverseExpandContext/ReverseExpandState)
+  - ✅ authorization_model_id threading
+  - ✅ Contextual tuples through graph traversal
+  - ✅ Userset type constraint handling in TupleToUserset
+  - ✅ Parallel union/intersection/exclusion branches
+  - ✅ StreamedListObjects gRPC endpoint
+
+**Next Step**: Milestone 1.16 PR review and merge, then Phase 4 (Distributed Edge)
 
 **To continue**: Specify what you'd like to work on next!

--- a/crates/rsfga-api/Cargo.toml
+++ b/crates/rsfga-api/Cargo.toml
@@ -81,7 +81,6 @@ clap = { workspace = true }
 proptest = { workspace = true }
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
-tokio-stream = { workspace = true }
 futures = { workspace = true }
 criterion = { workspace = true }
 chrono = { workspace = true }

--- a/crates/rsfga-api/Cargo.toml
+++ b/crates/rsfga-api/Cargo.toml
@@ -71,6 +71,9 @@ moka = { workspace = true }
 # Concurrent collections
 dashmap = { workspace = true }
 
+# Streaming
+tokio-stream = { workspace = true }
+
 # CLI
 clap = { workspace = true }
 

--- a/crates/rsfga-api/proto/openfga/v1/openfga_service.proto
+++ b/crates/rsfga-api/proto/openfga/v1/openfga_service.proto
@@ -32,6 +32,9 @@ service OpenFGAService {
   // List objects a user has access to
   rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
 
+  // Stream objects a user has access to (server-streaming)
+  rpc StreamedListObjects(StreamedListObjectsRequest) returns (stream StreamedListObjectsResponse);
+
   // List users that have access to an object
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
 
@@ -278,6 +281,25 @@ message ListObjectsRequest {
 message ListObjectsResponse {
   repeated string objects = 1;
   bool truncated = 2;
+}
+
+// ============================================================
+// Streamed List Objects Request/Response
+// ============================================================
+
+message StreamedListObjectsRequest {
+  string store_id = 1;
+  string authorization_model_id = 2;
+  string type = 3;
+  string relation = 4;
+  string user = 5;
+  ContextualTupleKeys contextual_tuples = 6;
+  google.protobuf.Struct context = 7;
+  ConsistencyPreference consistency = 8;
+}
+
+message StreamedListObjectsResponse {
+  string object = 1;
 }
 
 // ============================================================

--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -1051,7 +1051,7 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
         // Create domain request using validated context if available
         let context = validated_context_map.unwrap_or_default();
 
-        let list_request = DomainListObjectsRequest::with_context(
+        let mut list_request = DomainListObjectsRequest::with_context(
             req.store_id,
             req.user,
             req.relation,
@@ -1059,6 +1059,11 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
             contextual_tuples,
             context,
         );
+        list_request.authorization_model_id = if req.authorization_model_id.is_empty() {
+            None
+        } else {
+            Some(req.authorization_model_id)
+        };
 
         // Call the resolver with DoS protection limit
         let result = self

--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -37,10 +37,11 @@ use crate::proto::openfga::v1::{
     ListStoresResponse, ListUsersRequest, ListUsersResponse, ReadAssertionsRequest,
     ReadAssertionsResponse, ReadAuthorizationModelRequest, ReadAuthorizationModelResponse,
     ReadAuthorizationModelsRequest, ReadAuthorizationModelsResponse, ReadChangesRequest,
-    ReadChangesResponse, ReadRequest, ReadResponse, RelationshipCondition, Store, Tuple,
-    TupleChange, TupleKey, TupleOperation, TypedWildcard, UpdateStoreRequest, UpdateStoreResponse,
-    User, UsersetTree, UsersetUser, WriteAssertionsRequest, WriteAssertionsResponse,
-    WriteAuthorizationModelRequest, WriteAuthorizationModelResponse, WriteRequest, WriteResponse,
+    ReadChangesResponse, ReadRequest, ReadResponse, RelationshipCondition, Store,
+    StreamedListObjectsRequest, StreamedListObjectsResponse, Tuple, TupleChange, TupleKey,
+    TupleOperation, TypedWildcard, UpdateStoreRequest, UpdateStoreResponse, User, UsersetTree,
+    UsersetUser, WriteAssertionsRequest, WriteAssertionsResponse, WriteAuthorizationModelRequest,
+    WriteAuthorizationModelResponse, WriteRequest, WriteResponse,
 };
 
 /// Maximum allowed length for correlation IDs to prevent DoS attacks.
@@ -286,6 +287,9 @@ const DEFAULT_PAGE_SIZE: i32 = 50;
 
 #[tonic::async_trait]
 impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
+    type StreamedListObjectsStream =
+        tokio_stream::wrappers::ReceiverStream<Result<StreamedListObjectsResponse, Status>>;
+
     async fn check(
         &self,
         request: Request<CheckRequest>,
@@ -1076,6 +1080,143 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
             objects: result.objects,
             truncated: result.truncated,
         }))
+    }
+
+    async fn streamed_list_objects(
+        &self,
+        request: Request<StreamedListObjectsRequest>,
+    ) -> Result<Response<Self::StreamedListObjectsStream>, Status> {
+        use crate::validation::{
+            estimate_context_size, json_exceeds_max_depth, validate_relation_format,
+            validate_user_format, MAX_CONDITION_CONTEXT_SIZE, MAX_JSON_DEPTH,
+            MAX_LIST_OBJECTS_CANDIDATES,
+        };
+        use rsfga_domain::resolver::ListObjectsRequest as DomainListObjectsRequest;
+        use rsfga_storage::traits::validate_object_type;
+
+        let req = request.into_inner();
+
+        // Validate object type format
+        if let Err(e) = validate_object_type(&req.r#type) {
+            return Err(Status::invalid_argument(e.to_string()));
+        }
+
+        // Validate user format
+        if let Some(err) = validate_user_format(&req.user) {
+            return Err(Status::invalid_argument(err));
+        }
+
+        // Validate relation format
+        if let Some(err) = validate_relation_format(&req.relation) {
+            return Err(Status::invalid_argument(err));
+        }
+
+        // Validate and parse context if provided
+        let mut validated_context_map = None;
+        if let Some(context_struct) = &req.context {
+            let context_map = prost_struct_to_hashmap(context_struct.clone())
+                .map_err(|e| Status::invalid_argument(format!("invalid context: {}", e)))?;
+
+            if estimate_context_size(&context_map) > MAX_CONDITION_CONTEXT_SIZE {
+                return Err(Status::invalid_argument(format!(
+                    "context size exceeds maximum of {MAX_CONDITION_CONTEXT_SIZE} bytes"
+                )));
+            }
+
+            for value in context_map.values() {
+                if json_exceeds_max_depth(value, 2) {
+                    return Err(Status::invalid_argument(format!(
+                        "context nested too deeply (max depth {MAX_JSON_DEPTH})"
+                    )));
+                }
+            }
+
+            validated_context_map = Some(context_map);
+        }
+
+        // Validate contextual tuple count before allocation
+        if let Some(ref ct) = req.contextual_tuples {
+            if ct.tuple_keys.len() > crate::validation::MAX_CONTEXTUAL_TUPLES {
+                return Err(Status::invalid_argument(format!(
+                    "too many contextual tuples: {} exceeds maximum of {}",
+                    ct.tuple_keys.len(),
+                    crate::validation::MAX_CONTEXTUAL_TUPLES
+                )));
+            }
+        }
+
+        // Convert contextual tuples if provided
+        let contextual_tuples = req
+            .contextual_tuples
+            .map(|ct| {
+                ct.tuple_keys
+                    .into_iter()
+                    .filter_map(|tk| {
+                        let user = parse_user(&tk.user);
+                        if user.is_none() {
+                            tracing::warn!("Invalid user format in contextual tuple: {}", tk.user);
+                            return None;
+                        }
+                        let (user_type, user_id, user_relation) = user.unwrap();
+
+                        let object = parse_object(&tk.object);
+                        if object.is_none() {
+                            tracing::warn!(
+                                "Invalid object format in contextual tuple: {}",
+                                tk.object
+                            );
+                            return None;
+                        }
+                        let (object_type, object_id) = object.unwrap();
+
+                        Some(rsfga_domain::resolver::ContextualTuple::new(
+                            format_user(user_type, user_id, user_relation),
+                            tk.relation,
+                            format!("{object_type}:{object_id}"),
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Create domain request using validated context if available
+        let context = validated_context_map.unwrap_or_default();
+
+        let mut list_request = DomainListObjectsRequest::with_context(
+            req.store_id,
+            req.user,
+            req.relation,
+            req.r#type,
+            contextual_tuples,
+            context,
+        );
+        list_request.authorization_model_id = if req.authorization_model_id.is_empty() {
+            None
+        } else {
+            Some(req.authorization_model_id)
+        };
+
+        // Call the resolver to get all results (collect then stream)
+        let result = self
+            .resolver
+            .list_objects(&list_request, MAX_LIST_OBJECTS_CANDIDATES)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        // Stream the results via a channel
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+
+        tokio::spawn(async move {
+            for obj in result.objects {
+                let resp = StreamedListObjectsResponse { object: obj };
+                if tx.send(Ok(resp)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        Ok(Response::new(stream))
     }
 
     async fn list_users(

--- a/crates/rsfga-api/src/grpc/service.rs
+++ b/crates/rsfga-api/src/grpc/service.rs
@@ -285,6 +285,127 @@ const MAX_AUTHORIZATION_MODEL_SIZE: usize = 1024 * 1024;
 /// Matches OpenFGA's default behavior to limit memory usage and response size.
 const DEFAULT_PAGE_SIZE: i32 = 50;
 
+/// Validates and builds a domain `ListObjectsRequest` from gRPC request fields.
+///
+/// Shared between `list_objects` and `streamed_list_objects` to avoid duplication.
+/// Handles validation, contextual tuple conversion (preserving conditions), and
+/// context parsing.
+#[allow(clippy::result_large_err)]
+fn build_list_objects_request(
+    store_id: String,
+    authorization_model_id: String,
+    r#type: String,
+    relation: String,
+    user: String,
+    contextual_tuples: Option<Vec<TupleKey>>,
+    context: Option<prost_types::Struct>,
+) -> Result<rsfga_domain::resolver::ListObjectsRequest, Status> {
+    use crate::validation::{
+        estimate_context_size, json_exceeds_max_depth, validate_relation_format,
+        validate_user_format, MAX_CONDITION_CONTEXT_SIZE, MAX_JSON_DEPTH,
+    };
+    use rsfga_storage::traits::validate_object_type;
+
+    // Validate object type format
+    if let Err(e) = validate_object_type(&r#type) {
+        return Err(Status::invalid_argument(e.to_string()));
+    }
+
+    // Validate user format
+    if let Some(err) = validate_user_format(&user) {
+        return Err(Status::invalid_argument(err));
+    }
+
+    // Validate relation format
+    if let Some(err) = validate_relation_format(&relation) {
+        return Err(Status::invalid_argument(err));
+    }
+
+    // Validate and parse context if provided
+    let validated_context_map = if let Some(context_struct) = context {
+        let context_map = prost_struct_to_hashmap(context_struct)
+            .map_err(|e| Status::invalid_argument(format!("invalid context: {}", e)))?;
+
+        if estimate_context_size(&context_map) > MAX_CONDITION_CONTEXT_SIZE {
+            return Err(Status::invalid_argument(format!(
+                "context size exceeds maximum of {MAX_CONDITION_CONTEXT_SIZE} bytes"
+            )));
+        }
+
+        for value in context_map.values() {
+            if json_exceeds_max_depth(value, 2) {
+                return Err(Status::invalid_argument(format!(
+                    "context nested too deeply (max depth {MAX_JSON_DEPTH})"
+                )));
+            }
+        }
+
+        context_map
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    // Validate contextual tuple count before allocation
+    if let Some(ref tks) = contextual_tuples {
+        if tks.len() > crate::validation::MAX_CONTEXTUAL_TUPLES {
+            return Err(Status::invalid_argument(format!(
+                "too many contextual tuples: {} exceeds maximum of {}",
+                tks.len(),
+                crate::validation::MAX_CONTEXTUAL_TUPLES
+            )));
+        }
+    }
+
+    // Convert contextual tuples, preserving conditions
+    let contextual_tuples: Vec<ContextualTuple> = contextual_tuples
+        .map(|tks| {
+            tks.into_iter()
+                .map(|tk| {
+                    if let Some(condition) = tk.condition {
+                        let context = condition
+                            .context
+                            .map(prost_struct_to_hashmap)
+                            .transpose()
+                            .map_err(|e| {
+                                Status::invalid_argument(format!(
+                                    "condition context invalid: tuple={}#{}@{}, error={}",
+                                    tk.user, tk.relation, tk.object, e
+                                ))
+                            })?;
+
+                        Ok(ContextualTuple::with_condition(
+                            &tk.user,
+                            &tk.relation,
+                            &tk.object,
+                            &condition.name,
+                            context,
+                        ))
+                    } else {
+                        Ok(ContextualTuple::new(&tk.user, &tk.relation, &tk.object))
+                    }
+                })
+                .collect::<Result<Vec<_>, Status>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let mut list_request = rsfga_domain::resolver::ListObjectsRequest::with_context(
+        store_id,
+        user,
+        relation,
+        r#type,
+        contextual_tuples,
+        validated_context_map,
+    );
+    list_request.authorization_model_id = if authorization_model_id.is_empty() {
+        None
+    } else {
+        Some(authorization_model_id)
+    };
+
+    Ok(list_request)
+}
+
 #[tonic::async_trait]
 impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
     type StreamedListObjectsStream =
@@ -956,120 +1077,19 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
         &self,
         request: Request<ListObjectsRequest>,
     ) -> Result<Response<ListObjectsResponse>, Status> {
-        use crate::validation::{
-            estimate_context_size, json_exceeds_max_depth, validate_relation_format,
-            validate_user_format, MAX_CONDITION_CONTEXT_SIZE, MAX_JSON_DEPTH,
-            MAX_LIST_OBJECTS_CANDIDATES,
-        };
-        use rsfga_domain::resolver::ListObjectsRequest as DomainListObjectsRequest;
-        use rsfga_storage::traits::validate_object_type;
+        use crate::validation::MAX_LIST_OBJECTS_CANDIDATES;
 
         let req = request.into_inner();
-
-        // Validate object type format
-        if let Err(e) = validate_object_type(&req.r#type) {
-            return Err(Status::invalid_argument(e.to_string()));
-        }
-
-        // Validate user format
-        if let Some(err) = validate_user_format(&req.user) {
-            return Err(Status::invalid_argument(err));
-        }
-
-        // Validate relation format
-        if let Some(err) = validate_relation_format(&req.relation) {
-            return Err(Status::invalid_argument(err));
-        }
-        let mut validated_context_map = None;
-        if let Some(context_struct) = &req.context {
-            // Check size (approximate from Struct)
-            // Note: This is an estimation. For strict limits, we might want to check the byte size of the request.
-            // But checking the converted JSON size is consistent with HTTP.
-            // We convert to JSON map early to check.
-            let context_map = prost_struct_to_hashmap(context_struct.clone())
-                .map_err(|e| Status::invalid_argument(format!("invalid context: {}", e)))?;
-
-            if estimate_context_size(&context_map) > MAX_CONDITION_CONTEXT_SIZE {
-                return Err(Status::invalid_argument(format!(
-                    "context size exceeds maximum of {MAX_CONDITION_CONTEXT_SIZE} bytes"
-                )));
-            }
-
-            // Check nesting depth
-            for value in context_map.values() {
-                if json_exceeds_max_depth(value, 2) {
-                    return Err(Status::invalid_argument(format!(
-                        "context nested too deeply (max depth {MAX_JSON_DEPTH})"
-                    )));
-                }
-            }
-
-            validated_context_map = Some(context_map);
-        }
-
-        // Validate contextual tuple count before allocation
-        if let Some(ref ct) = req.contextual_tuples {
-            if ct.tuple_keys.len() > crate::validation::MAX_CONTEXTUAL_TUPLES {
-                return Err(Status::invalid_argument(format!(
-                    "too many contextual tuples: {} exceeds maximum of {}",
-                    ct.tuple_keys.len(),
-                    crate::validation::MAX_CONTEXTUAL_TUPLES
-                )));
-            }
-        }
-
-        // Convert contextual tuples if provided, logging any that are skipped due to invalid format
-        let contextual_tuples = req
-            .contextual_tuples
-            .map(|ct| {
-                ct.tuple_keys
-                    .into_iter()
-                    .filter_map(|tk| {
-                        let user = parse_user(&tk.user);
-                        if user.is_none() {
-                            tracing::warn!("Invalid user format in contextual tuple: {}", tk.user);
-                            return None;
-                        }
-                        let (user_type, user_id, user_relation) = user.unwrap();
-
-                        let object = parse_object(&tk.object);
-                        if object.is_none() {
-                            tracing::warn!(
-                                "Invalid object format in contextual tuple: {}",
-                                tk.object
-                            );
-                            return None;
-                        }
-                        let (object_type, object_id) = object.unwrap();
-
-                        Some(rsfga_domain::resolver::ContextualTuple::new(
-                            format_user(user_type, user_id, user_relation),
-                            tk.relation,
-                            format!("{object_type}:{object_id}"),
-                        ))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // Create domain request using validated context if available
-        let context = validated_context_map.unwrap_or_default();
-
-        let mut list_request = DomainListObjectsRequest::with_context(
+        let list_request = build_list_objects_request(
             req.store_id,
-            req.user,
-            req.relation,
+            req.authorization_model_id,
             req.r#type,
-            contextual_tuples,
-            context,
-        );
-        list_request.authorization_model_id = if req.authorization_model_id.is_empty() {
-            None
-        } else {
-            Some(req.authorization_model_id)
-        };
+            req.relation,
+            req.user,
+            req.contextual_tuples.map(|ct| ct.tuple_keys),
+            req.context,
+        )?;
 
-        // Call the resolver with DoS protection limit
         let result = self
             .resolver
             .list_objects(&list_request, MAX_LIST_OBJECTS_CANDIDATES)
@@ -1086,115 +1106,18 @@ impl<S: DataStore> OpenFgaService for OpenFgaGrpcService<S> {
         &self,
         request: Request<StreamedListObjectsRequest>,
     ) -> Result<Response<Self::StreamedListObjectsStream>, Status> {
-        use crate::validation::{
-            estimate_context_size, json_exceeds_max_depth, validate_relation_format,
-            validate_user_format, MAX_CONDITION_CONTEXT_SIZE, MAX_JSON_DEPTH,
-            MAX_LIST_OBJECTS_CANDIDATES,
-        };
-        use rsfga_domain::resolver::ListObjectsRequest as DomainListObjectsRequest;
-        use rsfga_storage::traits::validate_object_type;
+        use crate::validation::MAX_LIST_OBJECTS_CANDIDATES;
 
         let req = request.into_inner();
-
-        // Validate object type format
-        if let Err(e) = validate_object_type(&req.r#type) {
-            return Err(Status::invalid_argument(e.to_string()));
-        }
-
-        // Validate user format
-        if let Some(err) = validate_user_format(&req.user) {
-            return Err(Status::invalid_argument(err));
-        }
-
-        // Validate relation format
-        if let Some(err) = validate_relation_format(&req.relation) {
-            return Err(Status::invalid_argument(err));
-        }
-
-        // Validate and parse context if provided
-        let mut validated_context_map = None;
-        if let Some(context_struct) = &req.context {
-            let context_map = prost_struct_to_hashmap(context_struct.clone())
-                .map_err(|e| Status::invalid_argument(format!("invalid context: {}", e)))?;
-
-            if estimate_context_size(&context_map) > MAX_CONDITION_CONTEXT_SIZE {
-                return Err(Status::invalid_argument(format!(
-                    "context size exceeds maximum of {MAX_CONDITION_CONTEXT_SIZE} bytes"
-                )));
-            }
-
-            for value in context_map.values() {
-                if json_exceeds_max_depth(value, 2) {
-                    return Err(Status::invalid_argument(format!(
-                        "context nested too deeply (max depth {MAX_JSON_DEPTH})"
-                    )));
-                }
-            }
-
-            validated_context_map = Some(context_map);
-        }
-
-        // Validate contextual tuple count before allocation
-        if let Some(ref ct) = req.contextual_tuples {
-            if ct.tuple_keys.len() > crate::validation::MAX_CONTEXTUAL_TUPLES {
-                return Err(Status::invalid_argument(format!(
-                    "too many contextual tuples: {} exceeds maximum of {}",
-                    ct.tuple_keys.len(),
-                    crate::validation::MAX_CONTEXTUAL_TUPLES
-                )));
-            }
-        }
-
-        // Convert contextual tuples if provided
-        let contextual_tuples = req
-            .contextual_tuples
-            .map(|ct| {
-                ct.tuple_keys
-                    .into_iter()
-                    .filter_map(|tk| {
-                        let user = parse_user(&tk.user);
-                        if user.is_none() {
-                            tracing::warn!("Invalid user format in contextual tuple: {}", tk.user);
-                            return None;
-                        }
-                        let (user_type, user_id, user_relation) = user.unwrap();
-
-                        let object = parse_object(&tk.object);
-                        if object.is_none() {
-                            tracing::warn!(
-                                "Invalid object format in contextual tuple: {}",
-                                tk.object
-                            );
-                            return None;
-                        }
-                        let (object_type, object_id) = object.unwrap();
-
-                        Some(rsfga_domain::resolver::ContextualTuple::new(
-                            format_user(user_type, user_id, user_relation),
-                            tk.relation,
-                            format!("{object_type}:{object_id}"),
-                        ))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // Create domain request using validated context if available
-        let context = validated_context_map.unwrap_or_default();
-
-        let mut list_request = DomainListObjectsRequest::with_context(
+        let list_request = build_list_objects_request(
             req.store_id,
-            req.user,
-            req.relation,
+            req.authorization_model_id,
             req.r#type,
-            contextual_tuples,
-            context,
-        );
-        list_request.authorization_model_id = if req.authorization_model_id.is_empty() {
-            None
-        } else {
-            Some(req.authorization_model_id)
-        };
+            req.relation,
+            req.user,
+            req.contextual_tuples.map(|ct| ct.tuple_keys),
+            req.context,
+        )?;
 
         // Call the resolver to get all results (collect then stream)
         let result = self

--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -3082,7 +3082,7 @@ async fn list_objects<S: DataStore>(
         contextual_tuples,
         body.context.unwrap_or_default(),
     );
-    list_request.authorization_model_id = body.authorization_model_id;
+    list_request.authorization_model_id = body.authorization_model_id.filter(|id| !id.is_empty());
 
     // Call the resolver with DoS protection limit
     let result = state

--- a/crates/rsfga-api/src/http/routes.rs
+++ b/crates/rsfga-api/src/http/routes.rs
@@ -3074,7 +3074,7 @@ async fn list_objects<S: DataStore>(
         .unwrap_or_default();
 
     // Create domain request
-    let list_request = ListObjectsRequest::with_context(
+    let mut list_request = ListObjectsRequest::with_context(
         store_id,
         body.user,
         body.relation,
@@ -3082,6 +3082,7 @@ async fn list_objects<S: DataStore>(
         contextual_tuples,
         body.context.unwrap_or_default(),
     );
+    list_request.authorization_model_id = body.authorization_model_id;
 
     // Call the resolver with DoS protection limit
     let result = state

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1366,6 +1366,26 @@ where
         }
     }
 
+    /// Lists objects accessible to a user with streaming results.
+    ///
+    /// Results are sent via the provided channel as they're discovered,
+    /// rather than being collected into a Vec. For the initial implementation,
+    /// this calls `list_objects` and streams the results. A future optimization
+    /// could modify `reverse_expand_objects` to send results through the channel
+    /// as they're discovered during graph traversal.
+    pub async fn list_objects_streamed(
+        &self,
+        request: &super::types::ListObjectsRequest,
+        tx: tokio::sync::mpsc::Sender<String>,
+    ) -> DomainResult<()> {
+        let result = self.list_objects(request, 1000).await?;
+        for obj in result.objects {
+            // Ignore send errors (receiver may have been dropped)
+            let _ = tx.send(obj).await;
+        }
+        Ok(())
+    }
+
     /// Inner implementation of list_objects without timeout wrapper.
     async fn list_objects_inner(
         &self,

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1438,35 +1438,6 @@ where
         self.reverse_expand_objects(&ctx, &mut state, &request.relation, &relation_def.rewrite)
             .await?;
 
-        // Add objects from contextual tuples that grant access
-        for ct in request.contextual_tuples.iter() {
-            if state.results.len() >= limit {
-                break;
-            }
-            if ct.user == request.user && ct.relation == request.relation {
-                if let Some((obj_type, _obj_id)) = ct.object.split_once(':') {
-                    if obj_type == request.object_type && !state.seen.contains(&ct.object) {
-                        // Evaluate condition if present (I1 correctness requirement)
-                        if ct.condition_name.is_some() {
-                            let condition_ok = self
-                                .evaluate_condition(
-                                    &request.store_id,
-                                    ct.condition_name.as_deref(),
-                                    ct.condition_context.as_ref(),
-                                    &request.context,
-                                )
-                                .await?;
-                            if !condition_ok {
-                                continue;
-                            }
-                        }
-                        state.seen.insert(ct.object.clone());
-                        state.results.push(ct.object.clone());
-                    }
-                }
-            }
-        }
-
         // Determine truncation - either from ReverseExpand hitting limits or result size
         let truncated = state.truncated || state.results.len() > max_candidates;
         if state.results.len() > max_candidates {
@@ -1566,6 +1537,55 @@ where
                                 // Hit limit - there are more objects we couldn't include
                                 state.truncated = true;
                                 break;
+                            }
+                        }
+                    }
+
+                    // Contextual tuple scan: find matching tuples from the request context.
+                    // This runs inside Userset::This so that ComputedUserset recursion
+                    // naturally discovers contextual tuples for the resolved relation.
+                    for ct in ctx.contextual_tuples {
+                        if state.results.len() >= ctx.limit {
+                            state.truncated = true;
+                            break;
+                        }
+                        if ct.relation == relation {
+                            let matches_user = ct.user == ctx.user
+                                || (ct.user.ends_with(":*") && {
+                                    // Wildcard: "type:*" matches any user of that type
+                                    if let Some((ct_user_type, _)) = ct.user.split_once(':') {
+                                        if let Some((user_type, _)) = ctx.user.split_once(':') {
+                                            ct_user_type == user_type
+                                        } else {
+                                            false
+                                        }
+                                    } else {
+                                        false
+                                    }
+                                });
+                            if matches_user {
+                                if let Some((obj_type, _)) = ct.object.split_once(':') {
+                                    if obj_type == ctx.object_type
+                                        && !state.seen.contains(&ct.object)
+                                    {
+                                        // Evaluate condition if present
+                                        if ct.condition_name.is_some() {
+                                            let condition_ok = self
+                                                .evaluate_condition(
+                                                    ctx.store_id,
+                                                    ct.condition_name.as_deref(),
+                                                    ct.condition_context.as_ref(),
+                                                    ctx.request_context,
+                                                )
+                                                .await?;
+                                            if !condition_ok {
+                                                continue;
+                                            }
+                                        }
+                                        state.seen.insert(ct.object.clone());
+                                        state.results.push(ct.object.clone());
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1411,9 +1411,15 @@ where
 
         // Get the relation definition to understand how access is computed
         // If the type or relation doesn't exist, return an error (OpenFGA compatibility - I2)
+        // When authorization_model_id is specified, pin the model version for consistency.
         let relation_def = self
             .model_reader
-            .get_relation_definition(&request.store_id, &request.object_type, &request.relation)
+            .get_relation_definition_with_model_id(
+                &request.store_id,
+                &request.object_type,
+                &request.relation,
+                request.authorization_model_id.as_deref(),
+            )
             .await?;
 
         // Build immutable context and mutable state for the ReverseExpand traversal
@@ -1425,6 +1431,7 @@ where
             request_context: &request.context,
             limit,
             max_depth: self.config.max_depth,
+            authorization_model_id: request.authorization_model_id.as_deref(),
         };
         let mut state = super::types::ReverseExpandState::new();
 
@@ -1578,7 +1585,12 @@ where
                     // Recursively expand the referenced relation on the same object type
                     let rel_def = self
                         .model_reader
-                        .get_relation_definition(ctx.store_id, ctx.object_type, computed_rel)
+                        .get_relation_definition_with_model_id(
+                            ctx.store_id,
+                            ctx.object_type,
+                            computed_rel,
+                            ctx.authorization_model_id,
+                        )
                         .await?;
 
                     state.depth += 1;
@@ -1604,7 +1616,12 @@ where
                     // We need to get the type from the tupleset relation's type constraints
                     let tupleset_def = self
                         .model_reader
-                        .get_relation_definition(ctx.store_id, ctx.object_type, tupleset)
+                        .get_relation_definition_with_model_id(
+                            ctx.store_id,
+                            ctx.object_type,
+                            tupleset,
+                            ctx.authorization_model_id,
+                        )
                         .await?;
 
                     // Extract parent types from type constraints
@@ -1622,7 +1639,12 @@ where
                         // Find parents where user has the computed_userset relation
                         let parent_rel_def = self
                             .model_reader
-                            .get_relation_definition(ctx.store_id, parent_type, computed_userset)
+                            .get_relation_definition_with_model_id(
+                                ctx.store_id,
+                                parent_type,
+                                computed_userset,
+                                ctx.authorization_model_id,
+                            )
                             .await;
 
                         // If the parent type doesn't have this relation, skip it
@@ -1652,6 +1674,7 @@ where
                             request_context: ctx.request_context,
                             limit: ctx.limit,
                             max_depth: ctx.max_depth,
+                            authorization_model_id: ctx.authorization_model_id,
                         };
                         let mut parent_state = super::types::ReverseExpandState {
                             seen: HashSet::new(),

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1813,32 +1813,48 @@ where
                 }
 
                 Userset::Union { children } => {
-                    // Union: collect results from all children
-                    // DepthLimitExceeded or CycleDetected in one branch should not prevent
-                    // collecting from others - just mark as truncated
-                    for child in children {
-                        if state.results.len() >= ctx.limit {
-                            state.truncated = true;
-                            break;
-                        }
-                        // Clone visited for each branch so cycles in one branch don't affect others
-                        let saved_visited = state.visited.clone();
-                        state.depth += 1;
-                        let result = self
-                            .reverse_expand_objects(ctx, state, relation, child)
-                            .await;
-                        state.depth -= 1;
-                        state.visited = saved_visited;
+                    // Union: evaluate all children concurrently
+                    let branch_futures: Vec<_> = children
+                        .iter()
+                        .map(|child| {
+                            let mut branch_state = state.fork();
+                            branch_state.depth = state.depth + 1;
+                            async move {
+                                let result = self
+                                    .reverse_expand_objects(ctx, &mut branch_state, relation, child)
+                                    .await;
+                                (branch_state, result)
+                            }
+                        })
+                        .collect();
 
+                    let branch_results = futures::future::join_all(branch_futures).await;
+
+                    // Merge results from all branches
+                    for (branch_state, result) in branch_results {
                         match result {
-                            Ok(()) => {}
+                            Ok(()) => {
+                                if branch_state.truncated {
+                                    state.truncated = true;
+                                }
+                            }
                             Err(DomainError::DepthLimitExceeded { .. })
                             | Err(DomainError::CycleDetected { .. }) => {
-                                // Track that results may be incomplete but continue
                                 state.truncated = true;
                             }
                             Err(e) => {
                                 return Err(e);
+                            }
+                        }
+                        // Merge branch results: add new objects not already seen
+                        for obj in branch_state.results {
+                            if state.results.len() >= ctx.limit {
+                                state.truncated = true;
+                                break;
+                            }
+                            if !state.seen.contains(&obj) {
+                                state.seen.insert(obj.clone());
+                                state.results.push(obj);
                             }
                         }
                     }
@@ -1850,56 +1866,37 @@ where
                         return Ok(());
                     }
 
-                    // Get results from first child
-                    let mut first_state = state.fork();
-                    first_state.depth = state.depth + 1;
-
-                    match self
-                        .reverse_expand_objects(ctx, &mut first_state, relation, &children[0])
-                        .await
-                    {
-                        Ok(()) => {
-                            if first_state.truncated {
-                                state.truncated = true;
+                    // Evaluate all children concurrently
+                    let branch_futures: Vec<_> = children
+                        .iter()
+                        .map(|child| {
+                            let mut branch_state = state.fork();
+                            branch_state.depth = state.depth + 1;
+                            async move {
+                                let result = self
+                                    .reverse_expand_objects(ctx, &mut branch_state, relation, child)
+                                    .await;
+                                (branch_state, result)
                             }
-                        }
-                        Err(DomainError::DepthLimitExceeded { .. })
-                        | Err(DomainError::CycleDetected { .. }) => {
-                            // If first branch fails, intersection is incomplete - mark truncated
-                            state.truncated = true;
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    }
+                        })
+                        .collect();
 
-                    let mut current_set: HashSet<String> =
-                        first_state.results.into_iter().collect();
+                    let branch_results = futures::future::join_all(branch_futures).await;
 
-                    // Intersect with results from remaining children
-                    for child in children.iter().skip(1) {
-                        if current_set.is_empty() {
-                            break;
-                        }
+                    // Process results: intersect all branches
+                    let mut current_set: Option<HashSet<String>> = None;
 
-                        let mut child_state = state.fork();
-                        child_state.depth = state.depth + 1;
-
-                        match self
-                            .reverse_expand_objects(ctx, &mut child_state, relation, child)
-                            .await
-                        {
+                    for (branch_state, result) in branch_results {
+                        match result {
                             Ok(()) => {
-                                if child_state.truncated {
+                                if branch_state.truncated {
                                     state.truncated = true;
                                 }
                             }
                             Err(DomainError::DepthLimitExceeded { .. })
                             | Err(DomainError::CycleDetected { .. }) => {
-                                // If any branch fails, intersection is incomplete
                                 state.truncated = true;
-                                current_set.clear();
+                                current_set = Some(HashSet::new()); // Empty intersection
                                 break;
                             }
                             Err(e) => {
@@ -1907,21 +1904,28 @@ where
                             }
                         }
 
-                        let child_set: HashSet<String> = child_state.results.into_iter().collect();
-                        // Use retain for in-place intersection, avoiding extra allocations
-                        current_set.retain(|obj| child_set.contains(obj));
+                        let branch_set: HashSet<String> =
+                            branch_state.results.into_iter().collect();
+                        current_set = Some(match current_set {
+                            None => branch_set,
+                            Some(mut existing) => {
+                                existing.retain(|obj| branch_set.contains(obj));
+                                existing
+                            }
+                        });
                     }
 
                     // Add intersection results to main results
-                    for obj in current_set {
-                        if !state.seen.contains(&obj) {
-                            if state.results.len() < ctx.limit {
-                                state.seen.insert(obj.clone());
-                                state.results.push(obj);
-                            } else {
-                                // Hit limit - there are more objects we couldn't include
-                                state.truncated = true;
-                                break;
+                    if let Some(intersection) = current_set {
+                        for obj in intersection {
+                            if !state.seen.contains(&obj) {
+                                if state.results.len() < ctx.limit {
+                                    state.seen.insert(obj.clone());
+                                    state.results.push(obj);
+                                } else {
+                                    state.truncated = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -1931,11 +1935,17 @@ where
                     // Exclusion: get base results minus subtract results
                     let mut base_state = state.fork();
                     base_state.depth = state.depth + 1;
+                    let mut subtract_state = state.fork();
+                    subtract_state.depth = state.depth + 1;
 
-                    match self
-                        .reverse_expand_objects(ctx, &mut base_state, relation, base)
-                        .await
-                    {
+                    // Evaluate base and subtract concurrently
+                    let (base_result, subtract_result) = tokio::join!(
+                        self.reverse_expand_objects(ctx, &mut base_state, relation, base),
+                        self.reverse_expand_objects(ctx, &mut subtract_state, relation, subtract)
+                    );
+
+                    // Process base result
+                    match base_result {
                         Ok(()) => {
                             if base_state.truncated {
                                 state.truncated = true;
@@ -1952,13 +1962,8 @@ where
                         }
                     }
 
-                    let mut subtract_state = state.fork();
-                    subtract_state.depth = state.depth + 1;
-
-                    match self
-                        .reverse_expand_objects(ctx, &mut subtract_state, relation, subtract)
-                        .await
-                    {
+                    // Process subtract result
+                    match subtract_result {
                         Ok(()) => {
                             if subtract_state.truncated {
                                 // If subtract was truncated, we might include objects that
@@ -1987,7 +1992,6 @@ where
                                 state.seen.insert(obj.clone());
                                 state.results.push(obj);
                             } else {
-                                // Hit limit - there are more objects we couldn't include
                                 state.truncated = true;
                                 break;
                             }

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1376,9 +1376,10 @@ where
     pub async fn list_objects_streamed(
         &self,
         request: &super::types::ListObjectsRequest,
+        max_candidates: usize,
         tx: tokio::sync::mpsc::Sender<String>,
     ) -> DomainResult<()> {
-        let result = self.list_objects(request, 1000).await?;
+        let result = self.list_objects(request, max_candidates).await?;
         for obj in result.objects {
             // Ignore send errors (receiver may have been dropped)
             let _ = tx.send(obj).await;

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1409,11 +1409,6 @@ where
 
         let limit = max_candidates.saturating_add(1);
 
-        // Use ReverseExpand algorithm to efficiently find accessible objects
-        // This traverses the model backwards from the user, avoiding O(n) scans
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut result_objects: Vec<String> = Vec::new();
-
         // Get the relation definition to understand how access is computed
         // If the type or relation doesn't exist, return an error (OpenFGA compatibility - I2)
         let relation_def = self
@@ -1421,36 +1416,29 @@ where
             .get_relation_definition(&request.store_id, &request.object_type, &request.relation)
             .await?;
 
-        // Use ReverseExpand to find all accessible objects
-        // visited tracks (object_type, relation) pairs to detect cycles
-        let mut visited: HashSet<String> = HashSet::new();
-        let mut was_truncated = false;
-
-        self.reverse_expand_objects(
-            &request.store_id,
-            &request.user,
-            &request.object_type,
-            &request.relation,
-            &relation_def.rewrite,
-            &mut seen,
-            &mut result_objects,
-            &mut visited,
-            &mut was_truncated,
-            &request.context,
+        // Build immutable context and mutable state for the ReverseExpand traversal
+        let ctx = super::types::ReverseExpandContext {
+            store_id: &request.store_id,
+            user: &request.user,
+            object_type: &request.object_type,
+            contextual_tuples: &request.contextual_tuples,
+            request_context: &request.context,
             limit,
-            0,                     // depth
-            self.config.max_depth, // max_depth
-        )
-        .await?;
+            max_depth: self.config.max_depth,
+        };
+        let mut state = super::types::ReverseExpandState::new();
+
+        self.reverse_expand_objects(&ctx, &mut state, &request.relation, &relation_def.rewrite)
+            .await?;
 
         // Add objects from contextual tuples that grant access
         for ct in request.contextual_tuples.iter() {
-            if result_objects.len() >= limit {
+            if state.results.len() >= limit {
                 break;
             }
             if ct.user == request.user && ct.relation == request.relation {
                 if let Some((obj_type, _obj_id)) = ct.object.split_once(':') {
-                    if obj_type == request.object_type && !seen.contains(&ct.object) {
+                    if obj_type == request.object_type && !state.seen.contains(&ct.object) {
                         // Evaluate condition if present (I1 correctness requirement)
                         if ct.condition_name.is_some() {
                             let condition_ok = self
@@ -1465,21 +1453,21 @@ where
                                 continue;
                             }
                         }
-                        seen.insert(ct.object.clone());
-                        result_objects.push(ct.object.clone());
+                        state.seen.insert(ct.object.clone());
+                        state.results.push(ct.object.clone());
                     }
                 }
             }
         }
 
         // Determine truncation - either from ReverseExpand hitting limits or result size
-        let truncated = was_truncated || result_objects.len() > max_candidates;
-        if result_objects.len() > max_candidates {
-            result_objects.truncate(max_candidates);
+        let truncated = state.truncated || state.results.len() > max_candidates;
+        if state.results.len() > max_candidates {
+            state.results.truncate(max_candidates);
         }
 
         Ok(super::types::ListObjectsResult {
-            objects: result_objects,
+            objects: state.results,
             truncated,
         })
     }
@@ -1508,33 +1496,25 @@ where
     ///
     /// The `truncated` flag is set to true if any branch of the traversal hits limits,
     /// ensuring callers know the results may be incomplete.
-    #[allow(clippy::too_many_arguments)]
     fn reverse_expand_objects<'a>(
         &'a self,
-        store_id: &'a str,
-        user: &'a str,
-        object_type: &'a str,
+        ctx: &'a super::types::ReverseExpandContext<'a>,
+        state: &'a mut super::types::ReverseExpandState,
         relation: &'a str,
         userset: &'a Userset,
-        seen: &'a mut HashSet<String>,
-        results: &'a mut Vec<String>,
-        visited: &'a mut HashSet<String>,
-        truncated: &'a mut bool,
-        request_context: &'a HashMap<String, serde_json::Value>,
-        limit: usize,
-        depth: u32,
-        max_depth: u32,
     ) -> BoxFuture<'a, DomainResult<()>> {
         Box::pin(async move {
             // Depth limit protection (DoS prevention)
             // Return error for consistency with other depth checks in the codebase
-            if depth >= max_depth {
-                return Err(DomainError::DepthLimitExceeded { max_depth });
+            if state.depth >= ctx.max_depth {
+                return Err(DomainError::DepthLimitExceeded {
+                    max_depth: ctx.max_depth,
+                });
             }
 
             // Check if we've hit the result limit (not an error, just stop collecting)
-            if results.len() >= limit {
-                *truncated = true;
+            if state.results.len() >= ctx.limit {
+                state.truncated = true;
                 return Ok(());
             }
 
@@ -1544,11 +1524,11 @@ where
                     let direct_objects = self
                         .tuple_reader
                         .get_objects_for_user(
-                            store_id,
-                            user,
-                            object_type,
+                            ctx.store_id,
+                            ctx.user,
+                            ctx.object_type,
                             Some(relation),
-                            limit.saturating_sub(results.len()),
+                            ctx.limit.saturating_sub(state.results.len()),
                         )
                         .await?;
 
@@ -1557,10 +1537,10 @@ where
                         if tuple_info.condition_name.is_some() {
                             let condition_ok = self
                                 .evaluate_condition(
-                                    store_id,
+                                    ctx.store_id,
                                     tuple_info.condition_name.as_deref(),
                                     tuple_info.condition_context.as_ref(),
-                                    request_context,
+                                    ctx.request_context,
                                 )
                                 .await?;
 
@@ -1570,14 +1550,14 @@ where
                             }
                         }
 
-                        let full_obj = format!("{}:{}", object_type, tuple_info.object_id);
-                        if !seen.contains(&full_obj) {
-                            if results.len() < limit {
-                                seen.insert(full_obj.clone());
-                                results.push(full_obj);
+                        let full_obj = format!("{}:{}", ctx.object_type, tuple_info.object_id);
+                        if !state.seen.contains(&full_obj) {
+                            if state.results.len() < ctx.limit {
+                                state.seen.insert(full_obj.clone());
+                                state.results.push(full_obj);
                             } else {
                                 // Hit limit - there are more objects we couldn't include
-                                *truncated = true;
+                                state.truncated = true;
                                 break;
                             }
                         }
@@ -1589,37 +1569,25 @@ where
                 } => {
                     // Cycle detection: check before traversing to a new relation
                     // This detects cycles like `define viewer: viewer` or mutual recursion
-                    let cycle_key = format!("{}:{}", object_type, computed_rel);
-                    if visited.contains(&cycle_key) {
+                    let cycle_key = format!("{}:{}", ctx.object_type, computed_rel);
+                    if state.visited.contains(&cycle_key) {
                         return Err(DomainError::CycleDetected { path: cycle_key });
                     }
-                    visited.insert(cycle_key.clone());
+                    state.visited.insert(cycle_key.clone());
 
                     // Recursively expand the referenced relation on the same object type
                     let rel_def = self
                         .model_reader
-                        .get_relation_definition(store_id, object_type, computed_rel)
+                        .get_relation_definition(ctx.store_id, ctx.object_type, computed_rel)
                         .await?;
 
+                    state.depth += 1;
                     let result = self
-                        .reverse_expand_objects(
-                            store_id,
-                            user,
-                            object_type,
-                            computed_rel,
-                            &rel_def.rewrite,
-                            seen,
-                            results,
-                            visited,
-                            truncated,
-                            request_context,
-                            limit,
-                            depth + 1,
-                            max_depth,
-                        )
+                        .reverse_expand_objects(ctx, state, computed_rel, &rel_def.rewrite)
                         .await;
+                    state.depth -= 1;
 
-                    visited.remove(&cycle_key);
+                    state.visited.remove(&cycle_key);
                     result?;
                 }
 
@@ -1636,7 +1604,7 @@ where
                     // We need to get the type from the tupleset relation's type constraints
                     let tupleset_def = self
                         .model_reader
-                        .get_relation_definition(store_id, object_type, tupleset)
+                        .get_relation_definition(ctx.store_id, ctx.object_type, tupleset)
                         .await?;
 
                     // Extract parent types from type constraints
@@ -1654,7 +1622,7 @@ where
                         // Find parents where user has the computed_userset relation
                         let parent_rel_def = self
                             .model_reader
-                            .get_relation_definition(store_id, parent_type, computed_userset)
+                            .get_relation_definition(ctx.store_id, parent_type, computed_userset)
                             .await;
 
                         // If the parent type doesn't have this relation, skip it
@@ -1668,52 +1636,55 @@ where
 
                         // Cycle detection: check before traversing to parent type's relation
                         let parent_cycle_key = format!("{}:{}", parent_type, computed_userset);
-                        if visited.contains(&parent_cycle_key) {
+                        if state.visited.contains(&parent_cycle_key) {
                             // Skip this type constraint - cycle detected
-                            *truncated = true;
+                            state.truncated = true;
                             continue;
                         }
-                        visited.insert(parent_cycle_key.clone());
+                        state.visited.insert(parent_cycle_key.clone());
 
-                        // Use ReverseExpand to find accessible parents
-                        let mut parent_seen: HashSet<String> = HashSet::new();
-                        let mut parent_results: Vec<String> = Vec::new();
-                        let mut parent_visited: HashSet<String> = visited.clone();
-                        let mut parent_truncated = false;
+                        // Build a child context for the parent type traversal
+                        let parent_ctx = super::types::ReverseExpandContext {
+                            store_id: ctx.store_id,
+                            user: ctx.user,
+                            object_type: parent_type,
+                            contextual_tuples: ctx.contextual_tuples,
+                            request_context: ctx.request_context,
+                            limit: ctx.limit,
+                            max_depth: ctx.max_depth,
+                        };
+                        let mut parent_state = super::types::ReverseExpandState {
+                            seen: HashSet::new(),
+                            visited: state.visited.clone(),
+                            results: Vec::new(),
+                            truncated: false,
+                            depth: state.depth + 1,
+                        };
 
                         // Handle depth limit and cycle errors in parent traversal - continue to
                         // next type constraint rather than failing the entire operation
                         let parent_result = self
                             .reverse_expand_objects(
-                                store_id,
-                                user,
-                                parent_type,
+                                &parent_ctx,
+                                &mut parent_state,
                                 computed_userset,
                                 &parent_rel_def.rewrite,
-                                &mut parent_seen,
-                                &mut parent_results,
-                                &mut parent_visited,
-                                &mut parent_truncated,
-                                request_context,
-                                limit, // Use limit for parents too
-                                depth + 1,
-                                max_depth,
                             )
                             .await;
 
-                        visited.remove(&parent_cycle_key);
+                        state.visited.remove(&parent_cycle_key);
 
                         match parent_result {
                             Ok(()) => {
-                                if parent_truncated {
-                                    *truncated = true;
+                                if parent_state.truncated {
+                                    state.truncated = true;
                                 }
                             }
                             Err(DomainError::DepthLimitExceeded { .. })
                             | Err(DomainError::CycleDetected { .. }) => {
                                 // Depth limit or cycle in parent traversal - skip this type
                                 // constraint but continue with others
-                                *truncated = true;
+                                state.truncated = true;
                                 continue;
                             }
                             Err(e) => {
@@ -1721,13 +1692,14 @@ where
                             }
                         }
 
-                        if parent_results.is_empty() {
+                        if parent_state.results.is_empty() {
                             continue;
                         }
 
                         // Step 2: Find child objects that have these parents via tupleset
                         // Extract just the IDs from the parent results
-                        let parent_ids: Vec<String> = parent_results
+                        let parent_ids: Vec<String> = parent_state
+                            .results
                             .iter()
                             .filter_map(|p| p.split_once(':').map(|(_, id)| id.to_string()))
                             .collect();
@@ -1741,12 +1713,12 @@ where
                         let child_tuples = self
                             .tuple_reader
                             .get_objects_with_parents(
-                                store_id,
-                                object_type,
+                                ctx.store_id,
+                                ctx.object_type,
                                 tupleset,
                                 parent_type,
                                 &parent_ids,
-                                limit.saturating_sub(results.len()),
+                                ctx.limit.saturating_sub(state.results.len()),
                             )
                             .await?;
 
@@ -1757,10 +1729,10 @@ where
                             if child_tuple.condition_name.is_some() {
                                 let condition_ok = self
                                     .evaluate_condition(
-                                        store_id,
+                                        ctx.store_id,
                                         child_tuple.condition_name.as_deref(),
                                         child_tuple.condition_context.as_ref(),
-                                        request_context,
+                                        ctx.request_context,
                                     )
                                     .await?;
 
@@ -1770,14 +1742,14 @@ where
                                 }
                             }
 
-                            let full_obj = format!("{}:{}", object_type, child_tuple.object_id);
-                            if !seen.contains(&full_obj) {
-                                if results.len() < limit {
-                                    seen.insert(full_obj.clone());
-                                    results.push(full_obj);
+                            let full_obj = format!("{}:{}", ctx.object_type, child_tuple.object_id);
+                            if !state.seen.contains(&full_obj) {
+                                if state.results.len() < ctx.limit {
+                                    state.seen.insert(full_obj.clone());
+                                    state.results.push(full_obj);
                                 } else {
                                     // Hit limit - there are more objects we couldn't include
-                                    *truncated = true;
+                                    state.truncated = true;
                                     break;
                                 }
                             }
@@ -1790,35 +1762,25 @@ where
                     // DepthLimitExceeded or CycleDetected in one branch should not prevent
                     // collecting from others - just mark as truncated
                     for child in children {
-                        if results.len() >= limit {
-                            *truncated = true;
+                        if state.results.len() >= ctx.limit {
+                            state.truncated = true;
                             break;
                         }
                         // Clone visited for each branch so cycles in one branch don't affect others
-                        let mut branch_visited = visited.clone();
-                        match self
-                            .reverse_expand_objects(
-                                store_id,
-                                user,
-                                object_type,
-                                relation,
-                                child,
-                                seen,
-                                results,
-                                &mut branch_visited,
-                                truncated,
-                                request_context,
-                                limit,
-                                depth + 1,
-                                max_depth,
-                            )
-                            .await
-                        {
+                        let saved_visited = state.visited.clone();
+                        state.depth += 1;
+                        let result = self
+                            .reverse_expand_objects(ctx, state, relation, child)
+                            .await;
+                        state.depth -= 1;
+                        state.visited = saved_visited;
+
+                        match result {
                             Ok(()) => {}
                             Err(DomainError::DepthLimitExceeded { .. })
                             | Err(DomainError::CycleDetected { .. }) => {
                                 // Track that results may be incomplete but continue
-                                *truncated = true;
+                                state.truncated = true;
                             }
                             Err(e) => {
                                 return Err(e);
@@ -1834,38 +1796,22 @@ where
                     }
 
                     // Get results from first child
-                    let mut intersection_seen: HashSet<String> = HashSet::new();
-                    let mut first_results: Vec<String> = Vec::new();
-                    let mut first_visited = visited.clone();
-                    let mut first_truncated = false;
+                    let mut first_state = state.fork();
+                    first_state.depth = state.depth + 1;
 
                     match self
-                        .reverse_expand_objects(
-                            store_id,
-                            user,
-                            object_type,
-                            relation,
-                            &children[0],
-                            &mut intersection_seen,
-                            &mut first_results,
-                            &mut first_visited,
-                            &mut first_truncated,
-                            request_context,
-                            limit,
-                            depth + 1,
-                            max_depth,
-                        )
+                        .reverse_expand_objects(ctx, &mut first_state, relation, &children[0])
                         .await
                     {
                         Ok(()) => {
-                            if first_truncated {
-                                *truncated = true;
+                            if first_state.truncated {
+                                state.truncated = true;
                             }
                         }
                         Err(DomainError::DepthLimitExceeded { .. })
                         | Err(DomainError::CycleDetected { .. }) => {
                             // If first branch fails, intersection is incomplete - mark truncated
-                            *truncated = true;
+                            state.truncated = true;
                             return Ok(());
                         }
                         Err(e) => {
@@ -1873,7 +1819,8 @@ where
                         }
                     }
 
-                    let mut current_set: HashSet<String> = first_results.into_iter().collect();
+                    let mut current_set: HashSet<String> =
+                        first_state.results.into_iter().collect();
 
                     // Intersect with results from remaining children
                     for child in children.iter().skip(1) {
@@ -1881,38 +1828,22 @@ where
                             break;
                         }
 
-                        let mut child_seen: HashSet<String> = HashSet::new();
-                        let mut child_results: Vec<String> = Vec::new();
-                        let mut child_visited = visited.clone();
-                        let mut child_truncated = false;
+                        let mut child_state = state.fork();
+                        child_state.depth = state.depth + 1;
 
                         match self
-                            .reverse_expand_objects(
-                                store_id,
-                                user,
-                                object_type,
-                                relation,
-                                child,
-                                &mut child_seen,
-                                &mut child_results,
-                                &mut child_visited,
-                                &mut child_truncated,
-                                request_context,
-                                limit,
-                                depth + 1,
-                                max_depth,
-                            )
+                            .reverse_expand_objects(ctx, &mut child_state, relation, child)
                             .await
                         {
                             Ok(()) => {
-                                if child_truncated {
-                                    *truncated = true;
+                                if child_state.truncated {
+                                    state.truncated = true;
                                 }
                             }
                             Err(DomainError::DepthLimitExceeded { .. })
                             | Err(DomainError::CycleDetected { .. }) => {
                                 // If any branch fails, intersection is incomplete
-                                *truncated = true;
+                                state.truncated = true;
                                 current_set.clear();
                                 break;
                             }
@@ -1921,20 +1852,20 @@ where
                             }
                         }
 
-                        let child_set: HashSet<String> = child_results.into_iter().collect();
+                        let child_set: HashSet<String> = child_state.results.into_iter().collect();
                         // Use retain for in-place intersection, avoiding extra allocations
                         current_set.retain(|obj| child_set.contains(obj));
                     }
 
                     // Add intersection results to main results
                     for obj in current_set {
-                        if !seen.contains(&obj) {
-                            if results.len() < limit {
-                                seen.insert(obj.clone());
-                                results.push(obj);
+                        if !state.seen.contains(&obj) {
+                            if state.results.len() < ctx.limit {
+                                state.seen.insert(obj.clone());
+                                state.results.push(obj);
                             } else {
                                 // Hit limit - there are more objects we couldn't include
-                                *truncated = true;
+                                state.truncated = true;
                                 break;
                             }
                         }
@@ -1943,38 +1874,22 @@ where
 
                 Userset::Exclusion { base, subtract } => {
                     // Exclusion: get base results minus subtract results
-                    let mut base_seen: HashSet<String> = HashSet::new();
-                    let mut base_results: Vec<String> = Vec::new();
-                    let mut base_visited = visited.clone();
-                    let mut base_truncated = false;
+                    let mut base_state = state.fork();
+                    base_state.depth = state.depth + 1;
 
                     match self
-                        .reverse_expand_objects(
-                            store_id,
-                            user,
-                            object_type,
-                            relation,
-                            base,
-                            &mut base_seen,
-                            &mut base_results,
-                            &mut base_visited,
-                            &mut base_truncated,
-                            request_context,
-                            limit,
-                            depth + 1,
-                            max_depth,
-                        )
+                        .reverse_expand_objects(ctx, &mut base_state, relation, base)
                         .await
                     {
                         Ok(()) => {
-                            if base_truncated {
-                                *truncated = true;
+                            if base_state.truncated {
+                                state.truncated = true;
                             }
                         }
                         Err(DomainError::DepthLimitExceeded { .. })
                         | Err(DomainError::CycleDetected { .. }) => {
                             // If base fails, we can't compute exclusion reliably
-                            *truncated = true;
+                            state.truncated = true;
                             return Ok(());
                         }
                         Err(e) => {
@@ -1982,58 +1897,43 @@ where
                         }
                     }
 
-                    let mut subtract_seen: HashSet<String> = HashSet::new();
-                    let mut subtract_results: Vec<String> = Vec::new();
-                    let mut subtract_visited = visited.clone();
-                    let mut subtract_truncated = false;
+                    let mut subtract_state = state.fork();
+                    subtract_state.depth = state.depth + 1;
 
                     match self
-                        .reverse_expand_objects(
-                            store_id,
-                            user,
-                            object_type,
-                            relation,
-                            subtract,
-                            &mut subtract_seen,
-                            &mut subtract_results,
-                            &mut subtract_visited,
-                            &mut subtract_truncated,
-                            request_context,
-                            limit,
-                            depth + 1,
-                            max_depth,
-                        )
+                        .reverse_expand_objects(ctx, &mut subtract_state, relation, subtract)
                         .await
                     {
                         Ok(()) => {
-                            if subtract_truncated {
+                            if subtract_state.truncated {
                                 // If subtract was truncated, we might include objects that
                                 // should be excluded - mark as truncated
-                                *truncated = true;
+                                state.truncated = true;
                             }
                         }
                         Err(DomainError::DepthLimitExceeded { .. })
                         | Err(DomainError::CycleDetected { .. }) => {
                             // If subtract fails, we include all base results (conservative)
                             // but mark as truncated since we couldn't fully evaluate
-                            *truncated = true;
+                            state.truncated = true;
                         }
                         Err(e) => {
                             return Err(e);
                         }
                     }
 
-                    let subtract_set: HashSet<String> = subtract_results.into_iter().collect();
+                    let subtract_set: HashSet<String> =
+                        subtract_state.results.into_iter().collect();
 
                     // Add base results that are not in subtract
-                    for obj in base_results {
-                        if !subtract_set.contains(&obj) && !seen.contains(&obj) {
-                            if results.len() < limit {
-                                seen.insert(obj.clone());
-                                results.push(obj);
+                    for obj in base_state.results {
+                        if !subtract_set.contains(&obj) && !state.seen.contains(&obj) {
+                            if state.results.len() < ctx.limit {
+                                state.seen.insert(obj.clone());
+                                state.results.push(obj);
                             } else {
                                 // Hit limit - there are more objects we couldn't include
-                                *truncated = true;
+                                state.truncated = true;
                                 break;
                             }
                         }

--- a/crates/rsfga-domain/src/resolver/graph_resolver.rs
+++ b/crates/rsfga-domain/src/resolver/graph_resolver.rs
@@ -1646,23 +1646,35 @@ where
 
                     // Extract parent types from type constraints
                     for type_constraint in &tupleset_def.type_constraints {
-                        // Parse the type constraint (e.g., "folder" or "folder#member")
-                        // split('#').next().unwrap() handles both cases correctly and is safe
-                        // because type_name is a non-empty string from the model definition
-                        let parent_type = type_constraint.type_name.split('#').next().unwrap();
+                        // Parse userset type constraints: "team#member" -> (team, Some(member))
+                        // Plain type constraints: "folder" -> (folder, None)
+                        let (parent_type, parent_relation) =
+                            if let Some((base, rel)) = type_constraint.type_name.split_once('#') {
+                                (base, Some(rel))
+                            } else {
+                                (type_constraint.type_name.as_str(), None)
+                            };
 
                         // Skip if parent_type is empty, wildcard, or malformed
                         if parent_type.is_empty() || parent_type == "*" {
                             continue;
                         }
 
-                        // Find parents where user has the computed_userset relation
+                        // When the type constraint specifies a relation (e.g., team#member),
+                        // use that relation for parent resolution instead of computed_userset.
+                        // This is because userset references like team:X#member mean "the set
+                        // of entities with relation member on team:X", so we must resolve
+                        // parents using the member relation, not the computed_userset.
+                        let effective_relation =
+                            parent_relation.unwrap_or(computed_userset.as_str());
+
+                        // Find parents where user has the effective relation
                         let parent_rel_def = self
                             .model_reader
                             .get_relation_definition_with_model_id(
                                 ctx.store_id,
                                 parent_type,
-                                computed_userset,
+                                effective_relation,
                                 ctx.authorization_model_id,
                             )
                             .await;
@@ -1677,7 +1689,7 @@ where
                         };
 
                         // Cycle detection: check before traversing to parent type's relation
-                        let parent_cycle_key = format!("{}:{}", parent_type, computed_userset);
+                        let parent_cycle_key = format!("{}:{}", parent_type, effective_relation);
                         if state.visited.contains(&parent_cycle_key) {
                             // Skip this type constraint - cycle detected
                             state.truncated = true;
@@ -1710,7 +1722,7 @@ where
                             .reverse_expand_objects(
                                 &parent_ctx,
                                 &mut parent_state,
-                                computed_userset,
+                                effective_relation,
                                 &parent_rel_def.rewrite,
                             )
                             .await;

--- a/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
+++ b/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
@@ -9028,3 +9028,127 @@ async fn test_list_objects_contextual_tuples_with_wildcard() {
         "Expected document:public-doc to be accessible via wildcard user:* contextual tuple"
     );
 }
+
+// ========== Section: Userset Type Constraint in TupleToUserset ==========
+
+/// Tests that TupleToUserset correctly handles userset type constraints (e.g., team#member).
+///
+/// Model:
+///   type team
+///     relations
+///       define member: [user]
+///       define viewer: [user]
+///
+///   type project
+///     relations
+///       define team: [team#member]           -- userset type constraint
+///       define viewer: viewer from team       -- TTU: computed_userset is "viewer"
+///
+/// The type constraint `team#member` means tuples on the `team` relation reference
+/// `team:X#member` usersets. When resolving `viewer = viewer from team`, the algorithm
+/// must use the relation from the type constraint (`member`) for parent resolution,
+/// NOT the computed_userset (`viewer`).
+///
+/// Without the fix, the resolver incorrectly uses computed_userset ("viewer") to find
+/// parent team objects, which fails because alice has "member" not "viewer" on the team.
+#[tokio::test]
+async fn test_list_objects_tupleset_with_userset_type_constraint() {
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+
+    tuple_reader.add_store("store1").await;
+
+    // team type: has both member and viewer relations
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "team".to_string(),
+                relations: vec![
+                    RelationDefinition {
+                        name: "member".to_string(),
+                        type_constraints: vec!["user".into()],
+                        rewrite: Userset::This,
+                    },
+                    RelationDefinition {
+                        name: "viewer".to_string(),
+                        type_constraints: vec!["user".into()],
+                        rewrite: Userset::This,
+                    },
+                ],
+            },
+        )
+        .await;
+
+    // project type: team relation with userset type constraint, viewer via TTU
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "project".to_string(),
+                relations: vec![
+                    RelationDefinition {
+                        name: "team".to_string(),
+                        type_constraints: vec!["team#member".into()],
+                        rewrite: Userset::This,
+                    },
+                    RelationDefinition {
+                        name: "viewer".to_string(),
+                        type_constraints: vec![],
+                        rewrite: Userset::TupleToUserset {
+                            tupleset: "team".to_string(),
+                            computed_userset: "viewer".to_string(),
+                        },
+                    },
+                ],
+            },
+        )
+        .await;
+
+    // user:alice is a member of team:engineering
+    tuple_reader
+        .add_tuple(
+            "store1",
+            "team",
+            "engineering",
+            "member",
+            "user",
+            "alice",
+            None,
+        )
+        .await;
+
+    // team:engineering#member is assigned team relation on project:alpha
+    // This represents the userset reference stored in the team relation
+    tuple_reader
+        .add_tuple(
+            "store1",
+            "project",
+            "alpha",
+            "team",
+            "team",
+            "engineering",
+            Some("member"),
+        )
+        .await;
+
+    let resolver = GraphResolver::new(tuple_reader, model_reader);
+
+    let request = ListObjectsRequest::new("store1", "user:alice", "viewer", "project");
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    // Alice is a member of team:engineering, and project:alpha has team:engineering#member
+    // in its team relation, so alice should be a viewer of project:alpha via TTU.
+    assert!(
+        result.objects.contains(&"project:alpha".to_string()),
+        "Expected project:alpha in results via userset type constraint team#member, got: {:?}",
+        result.objects
+    );
+    assert_eq!(
+        result.objects.len(),
+        1,
+        "Expected exactly 1 result, got {:?}",
+        result.objects
+    );
+}

--- a/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
+++ b/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
@@ -8880,3 +8880,151 @@ async fn test_list_objects_without_authorization_model_id() {
     assert!(result.objects.contains(&"document:doc1".to_string()));
     assert!(!result.truncated);
 }
+
+// ============================================================
+// Contextual Tuples Through Graph Traversal Tests
+// ============================================================
+
+/// Tests that contextual tuples are discovered through ComputedUserset.
+///
+/// Model: can_access = viewer | editor (Union of ComputedUsersets)
+/// Contextual tuple: user:alice editor document:report
+/// ListObjects(user:alice, can_access, document) should include document:report
+/// because ComputedUserset(editor) recurses into editor -> Userset::This -> finds
+/// the contextual tuple matching relation="editor".
+#[tokio::test]
+async fn test_list_objects_contextual_tuples_through_computed_userset() {
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+
+    tuple_reader.add_store("store1").await;
+
+    // Document type with viewer, editor, and can_access relations
+    // can_access = viewer | editor (Union of ComputedUsersets)
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "document".to_string(),
+                relations: vec![
+                    RelationDefinition {
+                        name: "viewer".to_string(),
+                        type_constraints: vec!["user".into()],
+                        rewrite: Userset::This,
+                    },
+                    RelationDefinition {
+                        name: "editor".to_string(),
+                        type_constraints: vec!["user".into()],
+                        rewrite: Userset::This,
+                    },
+                    RelationDefinition {
+                        name: "can_access".to_string(),
+                        type_constraints: vec!["user".into()],
+                        rewrite: Userset::Union {
+                            children: vec![
+                                Userset::ComputedUserset {
+                                    relation: "viewer".to_string(),
+                                },
+                                Userset::ComputedUserset {
+                                    relation: "editor".to_string(),
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        )
+        .await;
+
+    // No stored tuples - only a contextual tuple
+    let resolver = GraphResolver::new(tuple_reader, model_reader);
+
+    let contextual_tuples = vec![ContextualTuple::new(
+        "user:alice",
+        "editor",
+        "document:report",
+    )];
+
+    let request = ListObjectsRequest::with_context(
+        "store1",
+        "user:alice",
+        "can_access",
+        "document",
+        contextual_tuples,
+        HashMap::new(),
+    );
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    // document:report should be found via can_access -> ComputedUserset(editor) -> This -> contextual tuple
+    assert_eq!(
+        result.objects.len(),
+        1,
+        "Expected 1 document via contextual tuple through ComputedUserset, got {:?}",
+        result.objects
+    );
+    assert!(
+        result.objects.contains(&"document:report".to_string()),
+        "Expected document:report to be accessible via editor contextual tuple through can_access ComputedUserset"
+    );
+}
+
+/// Tests that wildcard contextual tuples (user:*) are matched in ListObjects.
+///
+/// Contextual tuple: user:* viewer document:public-doc
+/// ListObjects(user:bob, viewer, document) should include document:public-doc
+/// because the wildcard "user:*" matches any user of type "user".
+#[tokio::test]
+async fn test_list_objects_contextual_tuples_with_wildcard() {
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+
+    tuple_reader.add_store("store1").await;
+
+    // Document type with viewer relation that allows wildcards
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "document".to_string(),
+                relations: vec![RelationDefinition {
+                    name: "viewer".to_string(),
+                    type_constraints: vec!["user".into()],
+                    rewrite: Userset::This,
+                }],
+            },
+        )
+        .await;
+
+    // No stored tuples - only a wildcard contextual tuple
+    let resolver = GraphResolver::new(tuple_reader, model_reader);
+
+    let contextual_tuples = vec![ContextualTuple::new(
+        "user:*",
+        "viewer",
+        "document:public-doc",
+    )];
+
+    let request = ListObjectsRequest::with_context(
+        "store1",
+        "user:bob",
+        "viewer",
+        "document",
+        contextual_tuples,
+        HashMap::new(),
+    );
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    // document:public-doc should be found because user:* matches user:bob
+    assert_eq!(
+        result.objects.len(),
+        1,
+        "Expected 1 document via wildcard contextual tuple, got {:?}",
+        result.objects
+    );
+    assert!(
+        result.objects.contains(&"document:public-doc".to_string()),
+        "Expected document:public-doc to be accessible via wildcard user:* contextual tuple"
+    );
+}

--- a/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
+++ b/crates/rsfga-domain/src/resolver/tests/resolver_tests.rs
@@ -8095,6 +8095,7 @@ async fn test_listobjects_contextual_overrides_stored() {
             },
         ]),
         context: std::sync::Arc::new(HashMap::new()),
+        authorization_model_id: None,
     };
     let result = resolver.list_objects(&request, 100).await.unwrap();
 
@@ -8788,4 +8789,94 @@ async fn test_listobjects_concurrent_requests_isolated() {
         assert!(!alice_objects.contains("document:doc3"));
         assert!(!bob_objects.contains("document:doc1"));
     }
+}
+
+/// Tests that authorization_model_id is threaded through ListObjects request
+/// to the resolver without errors. When a specific model ID is provided,
+/// all relation definition lookups use that model version.
+#[tokio::test]
+async fn test_list_objects_with_authorization_model_id() {
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+
+    tuple_reader.add_store("store1").await;
+
+    // Set up a simple direct relation model
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "document".to_string(),
+                relations: vec![RelationDefinition {
+                    name: "viewer".to_string(),
+                    type_constraints: vec!["user".into()],
+                    rewrite: Userset::This,
+                }],
+            },
+        )
+        .await;
+
+    // Add a direct tuple
+    tuple_reader
+        .add_tuple(
+            "store1", "document", "doc1", "viewer", "user", "alice", None,
+        )
+        .await;
+
+    let resolver = GraphResolver::new(tuple_reader, model_reader);
+
+    // Create request with authorization_model_id set
+    let mut request = ListObjectsRequest::new("store1", "user:alice", "viewer", "document");
+    request.authorization_model_id = Some("model-id-1".to_string());
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    // Should still find the document since MockModelReader returns the same model
+    // regardless of model ID. The key assertion is that the request completes
+    // without errors, proving the field is threaded through correctly.
+    assert_eq!(result.objects.len(), 1);
+    assert!(result.objects.contains(&"document:doc1".to_string()));
+    assert!(!result.truncated);
+}
+
+/// Tests that authorization_model_id=None (default) still works correctly,
+/// preserving backward compatibility with existing code.
+#[tokio::test]
+async fn test_list_objects_without_authorization_model_id() {
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+
+    tuple_reader.add_store("store1").await;
+
+    model_reader
+        .add_type(
+            "store1",
+            TypeDefinition {
+                type_name: "document".to_string(),
+                relations: vec![RelationDefinition {
+                    name: "viewer".to_string(),
+                    type_constraints: vec!["user".into()],
+                    rewrite: Userset::This,
+                }],
+            },
+        )
+        .await;
+
+    tuple_reader
+        .add_tuple(
+            "store1", "document", "doc1", "viewer", "user", "alice", None,
+        )
+        .await;
+
+    let resolver = GraphResolver::new(tuple_reader, model_reader);
+
+    // Create request without authorization_model_id (None - uses latest model)
+    let request = ListObjectsRequest::new("store1", "user:alice", "viewer", "document");
+    assert!(request.authorization_model_id.is_none());
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    assert_eq!(result.objects.len(), 1);
+    assert!(result.objects.contains(&"document:doc1".to_string()));
+    assert!(!result.truncated);
 }

--- a/crates/rsfga-domain/src/resolver/types.rs
+++ b/crates/rsfga-domain/src/resolver/types.rs
@@ -277,6 +277,9 @@ pub struct ListObjectsRequest {
     pub contextual_tuples: Arc<Vec<ContextualTuple>>,
     /// CEL evaluation context variables.
     pub context: Arc<HashMap<String, serde_json::Value>>,
+    /// Optional authorization model ID to pin the model version.
+    /// If None, uses the latest model (current behavior).
+    pub authorization_model_id: Option<String>,
 }
 
 impl ListObjectsRequest {
@@ -294,6 +297,7 @@ impl ListObjectsRequest {
             object_type: object_type.into(),
             contextual_tuples: Arc::new(Vec::new()),
             context: Arc::new(HashMap::new()),
+            authorization_model_id: None,
         }
     }
 
@@ -313,6 +317,7 @@ impl ListObjectsRequest {
             object_type: object_type.into(),
             contextual_tuples: Arc::new(contextual_tuples),
             context: Arc::new(context),
+            authorization_model_id: None,
         }
     }
 }
@@ -425,6 +430,7 @@ pub(crate) struct ReverseExpandContext<'a> {
     pub request_context: &'a HashMap<String, serde_json::Value>,
     pub limit: usize,
     pub max_depth: u32,
+    pub authorization_model_id: Option<&'a str>,
 }
 
 /// Mutable state that tracks progress during a ReverseExpand traversal.

--- a/crates/rsfga-domain/src/resolver/types.rs
+++ b/crates/rsfga-domain/src/resolver/types.rs
@@ -449,6 +449,7 @@ pub(crate) struct ReverseExpandState {
 
 impl ReverseExpandState {
     /// Create a new empty state at depth 0.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             seen: HashSet::new(),
@@ -463,6 +464,7 @@ impl ReverseExpandState {
     ///
     /// The forked state shares the `visited` set (cloned) but starts
     /// with fresh `seen` and `results`. Depth is preserved.
+    #[must_use]
     pub fn fork(&self) -> Self {
         Self {
             seen: HashSet::new(),

--- a/crates/rsfga-domain/src/resolver/types.rs
+++ b/crates/rsfga-domain/src/resolver/types.rs
@@ -1,6 +1,6 @@
 //! Types for the graph resolver.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Request for a permission check.
@@ -404,6 +404,68 @@ pub struct ListObjectsResult {
     pub objects: Vec<String>,
     /// Whether the results were truncated due to limits.
     pub truncated: bool,
+}
+
+// ============================================================
+// ReverseExpand Internal Types
+// ============================================================
+
+/// Immutable context shared across all branches of a ReverseExpand traversal.
+///
+/// This struct captures the request-scoped parameters that remain constant
+/// throughout the recursive graph traversal. Extracted from the 14-parameter
+/// `reverse_expand_objects` function to improve readability and enable future
+/// parallel branch evaluation (where context is shared via reference).
+#[derive(Debug)]
+pub(crate) struct ReverseExpandContext<'a> {
+    pub store_id: &'a str,
+    pub user: &'a str,
+    pub object_type: &'a str,
+    pub contextual_tuples: &'a [ContextualTuple],
+    pub request_context: &'a HashMap<String, serde_json::Value>,
+    pub limit: usize,
+    pub max_depth: u32,
+}
+
+/// Mutable state that tracks progress during a ReverseExpand traversal.
+///
+/// This struct captures the per-branch mutable state. It can be forked
+/// for parallel branch evaluation (union/intersection/exclusion) and
+/// merged back after branches complete.
+#[derive(Debug)]
+pub(crate) struct ReverseExpandState {
+    pub seen: HashSet<String>,
+    pub visited: HashSet<String>,
+    pub results: Vec<String>,
+    pub truncated: bool,
+    pub depth: u32,
+}
+
+impl ReverseExpandState {
+    /// Create a new empty state at depth 0.
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+            visited: HashSet::new(),
+            results: Vec::new(),
+            truncated: false,
+            depth: 0,
+        }
+    }
+
+    /// Fork the state for a parallel branch evaluation.
+    ///
+    /// The forked state shares the `visited` set (cloned) but starts
+    /// with fresh `seen` and `results`. Depth is preserved.
+    pub fn fork(&self) -> Self {
+        Self {
+            seen: HashSet::new(),
+            visited: self.visited.clone(),
+            results: Vec::new(),
+            truncated: false,
+            depth: self.depth,
+        }
+    }
 }
 
 // ============================================================

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -2526,7 +2526,7 @@ After reviewing this roadmap:
 | 3.0 API Wiring | ✅ Complete | HTTP + gRPC Check/BatchCheck cache (#324, #329, #330) |
 | 3.1 Benchmarking | ✅ Complete | Key construction + integration benchmarks (#325-#327) |
 
-### Milestone 1.16: ListObjects Full Resolver 🏗️ IN PROGRESS
+### Milestone 1.16: ListObjects Full Resolver 📝 IN REVIEW (#331)
 - Structural refactoring (ReverseExpandContext/State)
 - authorization_model_id threading
 - Contextual tuples through graph traversal

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -2515,8 +2515,26 @@ After reviewing this roadmap:
 | 2.0.5 Failure Handling | ✅ Complete | Circuit breaker, DLQ, sync fallback |
 | 2.0.6 Edge Sync Consumer | ✅ Complete | `rsfga-edge` daemon (69 tests) |
 
+### Phase 3: Precomputed Check ✅ COMPLETE
+- Valkey-backed precompute cache for sub-millisecond check latency
+- Worker daemon (`rsfga-precompute`) with model-change watcher
+- HTTP and gRPC cache wiring (Check + BatchCheck)
+
+| Milestone | Status | Description |
+|-----------|--------|-------------|
+| 3.0 Precompute Worker | ✅ Complete | Valkey cache, worker daemon (#323) |
+| 3.0 API Wiring | ✅ Complete | HTTP + gRPC Check/BatchCheck cache (#324, #329, #330) |
+| 3.1 Benchmarking | ✅ Complete | Key construction + integration benchmarks (#325-#327) |
+
+### Milestone 1.16: ListObjects Full Resolver 🏗️ IN PROGRESS
+- Structural refactoring (ReverseExpandContext/State)
+- authorization_model_id threading
+- Contextual tuples through graph traversal
+- Userset type constraint handling
+- Parallel union/intersection/exclusion
+- StreamedListObjects gRPC endpoint
+
 ### Next Phase
-- **Phase 3**: Precomputed Check (sub-millisecond latency)
 - **Phase 4**: Distributed Edge (global deployment)
 
 ---

--- a/docs/plans/2026-02-23-list-objects-full-resolver-design.md
+++ b/docs/plans/2026-02-23-list-objects-full-resolver-design.md
@@ -1,0 +1,233 @@
+# ListObjects Full Resolver Design
+
+**Date**: 2026-02-23
+**Status**: Approved
+**Milestone**: 1.16
+
+## Problem
+
+The current ListObjects implementation has six gaps compared to OpenFGA behavior:
+
+1. **`authorization_model_id` silently dropped** — Both HTTP and gRPC handlers accept this field but never pass it to the domain layer. ListObjects always uses the latest model.
+2. **Contextual tuples not threaded through graph traversal** — Only injected as a post-processing step for direct tuple matches; computed relations through contextual tuples are missed.
+3. **TupleToUserset strips userset type constraints** — `group#member` type constraints have `#member` stripped, losing the relation context.
+4. **Sequential union/intersection/exclusion branches** — Check uses `FuturesUnordered` for parallel evaluation; ListObjects iterates sequentially.
+5. **`StreamedListObjects` gRPC endpoint missing** — Proto doesn't define it; no streaming implementation exists.
+6. **No result caching** — Deferred to a future milestone.
+
+## Approach: Tidy First + Targeted Fixes
+
+Structural refactoring first, then behavioral changes on top.
+
+## Section 1: Structural — `ReverseExpandContext` + `ReverseExpandState`
+
+Extract the 13 parameters of `reverse_expand_objects` into two structs:
+
+### `ReverseExpandContext` (immutable, shared across parallel branches)
+
+```rust
+pub(crate) struct ReverseExpandContext<'a> {
+    pub store_id: &'a str,
+    pub user: &'a str,
+    pub object_type: &'a str,
+    pub authorization_model_id: Option<&'a str>,
+    pub contextual_tuples: &'a [ContextualTuple],
+    pub request_context: &'a HashMap<String, serde_json::Value>,
+    pub limit: usize,
+    pub max_depth: u32,
+}
+```
+
+### `ReverseExpandState` (mutable, forked per parallel branch)
+
+```rust
+pub(crate) struct ReverseExpandState {
+    pub seen: HashSet<String>,
+    pub visited: HashSet<String>,
+    pub results: Vec<String>,
+    pub truncated: bool,
+    pub depth: u32,
+}
+
+impl ReverseExpandState {
+    fn fork(&self) -> Self { /* clone seen+visited, fresh results, same depth */ }
+    fn merge_union(&mut self, branch: Self) { /* union seen, append results, or truncated */ }
+}
+```
+
+### Simplified signature
+
+```rust
+fn reverse_expand_objects<'a>(
+    &'a self,
+    ctx: &'a ReverseExpandContext<'a>,
+    state: &'a mut ReverseExpandState,
+    relation: &'a str,
+    userset: &'a Userset,
+) -> BoxFuture<'a, DomainResult<()>>
+```
+
+## Section 2: Correctness — `authorization_model_id`
+
+### Changes
+
+- **`ListObjectsRequest`** (`types.rs`): Add `pub authorization_model_id: Option<String>` field.
+- **HTTP handler** (`routes.rs`): Pass `body.authorization_model_id` into `ListObjectsRequest`.
+- **gRPC handler** (`service.rs`): Convert empty string to `None`, pass through.
+- **`list_objects_inner`**: If `authorization_model_id` is `Some`, use it when calling `get_relation_definition`. Otherwise use latest (current behavior).
+- **`ReverseExpandContext`**: Carries it so all recursive `get_relation_definition` calls use the same model version.
+
+Mirrors how Check handles model pinning.
+
+## Section 3: Correctness — Contextual Tuples Through Graph Traversal
+
+### Problem
+
+Contextual tuples are only scanned post-traversal for direct matches:
+```
+user:alice viewer document:x → found (post-processing)
+user:alice editor document:x → NOT found via computed "can_access = viewer | editor"
+```
+
+### Fix
+
+Move contextual tuple scanning into `reverse_expand_objects` at the `Userset::This` branch:
+
+```rust
+Userset::This => {
+    // 1. Storage lookup (existing)
+    let direct_objects = self.tuple_reader.get_objects_for_user(...).await?;
+    // ... process direct_objects ...
+
+    // 2. Contextual tuple scan (NEW)
+    for ct in ctx.contextual_tuples {
+        if ct.relation == relation {
+            let matches_user = ct.user == ctx.user
+                || ct.user.ends_with(":*")  // wildcard
+                // Also handle userset references in ct.user
+            ;
+            if matches_user {
+                if let Some((obj_type, _)) = ct.object.split_once(':') {
+                    if obj_type == ctx.object_type && !state.seen.contains(&ct.object) {
+                        // Evaluate condition if present
+                        state.seen.insert(ct.object.clone());
+                        state.results.push(ct.object.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Remove the post-processing pass in `list_objects_inner` (lines 1447-1473).
+
+`ComputedUserset` branches recursively call `reverse_expand_objects` with a different relation, which will now naturally find contextual tuples matching that computed relation.
+
+## Section 4: Correctness — TupleToUserset Userset Type Constraints
+
+### Problem
+
+Type constraints like `group#member` have `#member` stripped (line 1647):
+```rust
+type_constraint.type_name.split('#').next() // "group#member" → "group"
+```
+
+### Fix
+
+When a type constraint contains `#`, it's a userset reference. The algorithm must:
+
+1. Split `group#member` into base type `group` and relation `member`.
+2. Find objects of type `group` where the user has `member` relation (via `reverse_expand_objects` recursion or `get_objects_for_user`).
+3. Use those resolved objects as parent IDs for the tupleset lookup.
+
+For non-userset type constraints (no `#`), the current behavior is unchanged.
+
+## Section 5: Performance — Parallel Union/Intersection/Exclusion
+
+### Union
+
+Spawn all children concurrently with `FuturesUnordered`. Each branch gets a forked `ReverseExpandState`. After all complete, merge results (union of `seen`, append `results`). Errors in individual branches set `truncated = true` but don't fail the whole operation.
+
+### Intersection
+
+Evaluate first child, build candidate set. Evaluate remaining children concurrently. Intersect: only objects in ALL children survive. If any child fails or is truncated, mark result as truncated.
+
+### Exclusion
+
+Evaluate base and subtract concurrently via `tokio::join!`. Return base - subtract. If subtract is truncated, mark result as truncated (conservative).
+
+## Section 6: StreamedListObjects gRPC Endpoint
+
+### Proto additions (`openfga_service.proto`)
+
+```protobuf
+rpc StreamedListObjects(StreamedListObjectsRequest) returns (stream StreamedListObjectsResponse);
+
+message StreamedListObjectsRequest {
+    string store_id = 1;
+    string authorization_model_id = 2;
+    string type = 3;
+    string relation = 4;
+    string user = 5;
+    ContextualTupleKeys contextual_tuples = 6;
+    google.protobuf.Struct context = 7;
+    ConsistencyPreference consistency = 8;
+}
+
+message StreamedListObjectsResponse {
+    string object = 1;
+}
+```
+
+### Domain layer
+
+Add a streaming variant in the resolver:
+
+```rust
+pub async fn list_objects_streamed(
+    &self,
+    request: ListObjectsRequest,
+    tx: mpsc::Sender<String>,
+) -> DomainResult<()>
+```
+
+The `ReverseExpandState` can be adapted to send results via the channel as they're discovered, rather than collecting into a Vec.
+
+### gRPC handler
+
+Uses `tokio::sync::mpsc` channel + `ReceiverStream` for the tonic streaming response. The resolver runs in a spawned task.
+
+### Existing `list_objects` refactoring
+
+The existing `list_objects` method internally calls `list_objects_streamed`, collecting all results into a Vec. This avoids duplicating the traversal logic.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/rsfga-domain/src/resolver/types.rs` | Add `authorization_model_id` to `ListObjectsRequest`, add `ReverseExpandContext`/`State` |
+| `crates/rsfga-domain/src/resolver/graph_resolver.rs` | Refactor `reverse_expand_objects`, fix all 6 Userset branches, add `list_objects_streamed` |
+| `crates/rsfga-api/src/http/routes.rs` | Thread `authorization_model_id` |
+| `crates/rsfga-api/src/grpc/service.rs` | Thread `authorization_model_id`, add `StreamedListObjects` handler |
+| `crates/rsfga-api/proto/openfga/v1/openfga_service.proto` | Add `StreamedListObjects` RPC + messages |
+| `crates/rsfga-api/proto/openfga/v1/openfga.proto` | Add message types if not in service proto |
+
+## Testing Strategy
+
+- **Unit tests**: Each Userset branch with contextual tuples, model_id pinning, userset type constraints
+- **Integration tests**: Full resolver with parallel branches, streaming, edge cases
+- **Compatibility tests**: Existing Section 15 tests must still pass; Section 34 (StreamedListObjects) tests should now pass against RSFGA
+- **Property tests**: Random authorization models with contextual tuples
+
+## Invariants
+
+- **I1 (Correctness)**: Contextual tuples with conditions must be evaluated. Wildcard contextual tuples must be handled.
+- **I2 (Compatibility)**: `authorization_model_id` support matches OpenFGA behavior. StreamedListObjects proto is wire-compatible.
+- **I4 (Security)**: Depth limits, cycle detection, and timeout still enforced in all new paths.
+
+## Out of Scope
+
+- ListObjects result caching (future milestone)
+- ListUsers equivalent improvements (separate milestone, same patterns apply)
+- HTTP streaming endpoint (OpenFGA only supports gRPC streaming for ListObjects)

--- a/docs/plans/2026-02-23-list-objects-full-resolver-plan.md
+++ b/docs/plans/2026-02-23-list-objects-full-resolver-plan.md
@@ -1,0 +1,1039 @@
+# ListObjects Full Resolver Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Bring ListObjects to full parity with OpenFGA — correctness fixes, parallel graph traversal, and StreamedListObjects gRPC streaming.
+
+**Architecture:** Tidy First structural refactoring (extract `ReverseExpandContext`/`State` from 14-parameter function), then layer behavioral changes: `authorization_model_id` support, contextual tuples threaded through traversal, userset type constraint handling, parallel union/intersection/exclusion branches, and a new `StreamedListObjects` gRPC server-streaming endpoint.
+
+**Tech Stack:** Rust, Tokio (FuturesUnordered, mpsc), Tonic gRPC, protobuf
+
+**Design Doc:** `docs/plans/2026-02-23-list-objects-full-resolver-design.md`
+
+---
+
+## Task 1: Structural — Extract `ReverseExpandContext` and `ReverseExpandState`
+
+Pure structural change. All existing tests must pass before and after. No behavioral change.
+
+**Files:**
+- Modify: `crates/rsfga-domain/src/resolver/types.rs` (add structs after line 407)
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs:1370-2046` (refactor `list_objects_inner` + `reverse_expand_objects`)
+
+**Step 1: Run existing tests to establish baseline**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+```
+
+Expected: All ~15 list_objects tests pass.
+
+**Step 2: Add `ReverseExpandContext` and `ReverseExpandState` to `types.rs`**
+
+After the `ListObjectsResult` struct (line 407), add:
+
+```rust
+/// Immutable context for the ReverseExpand algorithm.
+/// Shared across parallel branches (Clone-free via references).
+pub(crate) struct ReverseExpandContext<'a> {
+    pub store_id: &'a str,
+    pub user: &'a str,
+    pub object_type: &'a str,
+    pub request_context: &'a HashMap<String, serde_json::Value>,
+    pub limit: usize,
+    pub max_depth: u32,
+}
+
+/// Mutable traversal state for the ReverseExpand algorithm.
+/// Forked per parallel branch, merged after completion.
+pub(crate) struct ReverseExpandState {
+    pub seen: HashSet<String>,
+    pub visited: HashSet<String>,
+    pub results: Vec<String>,
+    pub truncated: bool,
+    pub depth: u32,
+}
+
+impl ReverseExpandState {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+            visited: HashSet::new(),
+            results: Vec::new(),
+            truncated: false,
+            depth: 0,
+        }
+    }
+
+    /// Fork state for a parallel branch. Shares seen+visited (cloned),
+    /// but starts with empty results.
+    pub fn fork(&self) -> Self {
+        Self {
+            seen: self.seen.clone(),
+            visited: self.visited.clone(),
+            results: Vec::new(),
+            truncated: false,
+            depth: self.depth,
+        }
+    }
+
+    /// Merge results from a union branch back into this state.
+    pub fn merge_union(&mut self, branch: Self) {
+        for obj in branch.results {
+            if !self.seen.contains(&obj) {
+                self.seen.insert(obj.clone());
+                self.results.push(obj);
+            }
+        }
+        if branch.truncated {
+            self.truncated = true;
+        }
+    }
+}
+```
+
+Add required import at top of `types.rs`:
+```rust
+use std::collections::{HashMap, HashSet};
+```
+
+**Step 3: Refactor `reverse_expand_objects` signature**
+
+In `graph_resolver.rs`, change the signature from 14 parameters to:
+
+```rust
+fn reverse_expand_objects<'a>(
+    &'a self,
+    ctx: &'a ReverseExpandContext<'a>,
+    state: &'a mut ReverseExpandState,
+    relation: &'a str,
+    userset: &'a Userset,
+) -> BoxFuture<'a, DomainResult<()>>
+```
+
+Update the function body to use `ctx.store_id`, `ctx.user`, `ctx.object_type`, `ctx.request_context`, `ctx.limit`, `ctx.max_depth` instead of the old parameters, and `state.seen`, `state.results`, `state.visited`, `state.truncated`, `state.depth` instead of the mutable refs.
+
+**Step 4: Update `list_objects_inner` to construct context and state**
+
+In `list_objects_inner` (line 1370), replace the call site at lines 1429-1444:
+
+```rust
+let ctx = ReverseExpandContext {
+    store_id: &request.store_id,
+    user: &request.user,
+    object_type: &request.object_type,
+    request_context: &request.context,
+    limit,
+    max_depth: self.config.max_depth,
+};
+let mut state = ReverseExpandState::new();
+
+self.reverse_expand_objects(&ctx, &mut state, &request.relation, &relation_def.userset)
+    .await
+    .or_else(|e| match e {
+        DomainError::DepthLimitExceeded { .. } | DomainError::CycleDetected { .. } => {
+            state.truncated = true;
+            Ok(())
+        }
+        other => Err(other),
+    })?;
+
+let mut result_objects = state.results;
+let mut seen = state.seen;
+let was_truncated = state.truncated;
+```
+
+**Step 5: Update all recursive `reverse_expand_objects` call sites**
+
+Inside `reverse_expand_objects`, every recursive call (in `ComputedUserset`, `TupleToUserset`, `Union`, `Intersection`, `Exclusion` branches) must be updated to pass `ctx` and `state` (or forked state) instead of the individual parameters.
+
+Key call sites to update (approximate current lines):
+- `ComputedUserset` recursive call (~line 1612)
+- `TupleToUserset` parent resolution call (~line 1700)
+- `TupleToUserset` child resolution calls (~line 1740)
+- `Union` branch calls (~line 1810)
+- `Intersection` branch calls (~line 1880)
+- `Exclusion` base/subtract calls (~line 1970)
+
+**Step 6: Run tests to verify no behavioral change**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: All tests still pass. No clippy warnings.
+
+**Step 7: Commit**
+
+```bash
+git add crates/rsfga-domain/src/resolver/types.rs crates/rsfga-domain/src/resolver/graph_resolver.rs
+git commit -m "[STRUCTURAL] Extract ReverseExpandContext and ReverseExpandState from reverse_expand_objects
+
+Refactor the 14-parameter reverse_expand_objects function into a clean
+interface using two structs: ReverseExpandContext (immutable, shared) and
+ReverseExpandState (mutable, per-branch). No behavioral changes.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Correctness — `authorization_model_id` Support
+
+Thread `authorization_model_id` through the entire ListObjects pipeline.
+
+**Files:**
+- Modify: `crates/rsfga-domain/src/resolver/types.rs:267-317` (add field to `ListObjectsRequest`)
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs:1370-1444` (use `get_relation_definition_with_model_id`)
+- Modify: `crates/rsfga-api/src/http/routes.rs:3077-3084` (pass field)
+- Modify: `crates/rsfga-api/src/grpc/service.rs:1054-1061` (pass field)
+- Test: `crates/rsfga-domain/src/resolver/tests/resolver_tests.rs`
+
+**Step 1: Write failing test**
+
+In `resolver_tests.rs`, add a test that verifies `authorization_model_id` is respected (i.e., the resolver uses the specific model, not latest):
+
+```rust
+#[tokio::test]
+async fn test_list_objects_respects_authorization_model_id() {
+    // Setup: Two models for the same store, different relation definitions
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+    tuple_reader.add_store("store1").await;
+
+    // Model v1: document has "viewer" as direct (This)
+    // Model v2: document has "viewer" as computed from "editor"
+    // With model_id pinned to v1, should use direct lookup only
+    // (Details depend on MockModelReader capabilities for model-by-id lookup)
+
+    let resolver = GraphResolver::new(tuple_reader.clone(), model_reader.clone());
+    let mut request = ListObjectsRequest::new("store1", "user:alice", "viewer", "document");
+    request.authorization_model_id = Some("model-v1".to_string());
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+    // Assert behavior matches pinned model, not latest
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --lib -p rsfga-domain -- test_list_objects_respects_authorization_model_id
+```
+
+Expected: FAIL — `authorization_model_id` field doesn't exist on `ListObjectsRequest`.
+
+**Step 3: Add field to `ListObjectsRequest`**
+
+In `types.rs` line 267, add the field:
+
+```rust
+pub struct ListObjectsRequest {
+    pub store_id: String,
+    pub authorization_model_id: Option<String>,  // NEW
+    pub user: String,
+    pub relation: String,
+    pub object_type: String,
+    pub contextual_tuples: Arc<Vec<ContextualTuple>>,
+    pub context: Arc<HashMap<String, serde_json::Value>>,
+}
+```
+
+Update constructors `new()` and `with_context()` to set `authorization_model_id: None`.
+
+**Step 4: Add field to `ReverseExpandContext`**
+
+```rust
+pub(crate) struct ReverseExpandContext<'a> {
+    pub store_id: &'a str,
+    pub user: &'a str,
+    pub object_type: &'a str,
+    pub authorization_model_id: Option<&'a str>,  // NEW
+    pub request_context: &'a HashMap<String, serde_json::Value>,
+    pub limit: usize,
+    pub max_depth: u32,
+}
+```
+
+**Step 5: Update `list_objects_inner` to use model-ID-aware lookup**
+
+At line ~1421, change:
+```rust
+// Before:
+let relation_def = self.model_reader
+    .get_relation_definition(&request.store_id, &request.object_type, &request.relation)
+    .await?;
+
+// After:
+let relation_def = self.model_reader
+    .get_relation_definition_with_model_id(
+        &request.store_id,
+        &request.object_type,
+        &request.relation,
+        request.authorization_model_id.as_deref(),
+    )
+    .await?;
+```
+
+Also set `authorization_model_id` in the `ReverseExpandContext` construction.
+
+**Step 6: Update `reverse_expand_objects` to use model-ID-aware lookups**
+
+Every `get_relation_definition` call inside `reverse_expand_objects` (at `ComputedUserset` ~line 1601, `TupleToUserset` ~lines 1639/1657) must be changed to:
+
+```rust
+self.model_reader
+    .get_relation_definition_with_model_id(
+        ctx.store_id,
+        type_name,
+        relation_name,
+        ctx.authorization_model_id,
+    )
+    .await?
+```
+
+**Step 7: Thread field through HTTP handler**
+
+In `routes.rs` at lines 3077-3084, pass `body.authorization_model_id`:
+
+```rust
+let mut list_request = ListObjectsRequest::with_context(
+    store_id, body.user, body.relation, body.r#type,
+    contextual_tuples, body.context.unwrap_or_default(),
+);
+list_request.authorization_model_id = body.authorization_model_id;
+```
+
+Or add an `authorization_model_id` parameter to the `with_context` constructor.
+
+**Step 8: Thread field through gRPC handler**
+
+In `service.rs` at lines 1054-1061:
+
+```rust
+let authorization_model_id = if req.authorization_model_id.is_empty() {
+    None
+} else {
+    Some(req.authorization_model_id.clone())
+};
+
+let mut list_request = DomainListObjectsRequest::with_context(
+    req.store_id, req.user, req.relation, req.r#type,
+    contextual_tuples, context,
+);
+list_request.authorization_model_id = authorization_model_id;
+```
+
+**Step 9: Run tests**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+cargo test --lib -p rsfga-api
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: All pass, including the new test.
+
+**Step 10: Commit**
+
+```bash
+git add crates/rsfga-domain/ crates/rsfga-api/
+git commit -m "[BEHAVIORAL] Add authorization_model_id support to ListObjects
+
+Thread authorization_model_id through HTTP/gRPC handlers into the domain
+resolver. All recursive get_relation_definition calls in reverse_expand_objects
+now use get_relation_definition_with_model_id, pinning the entire graph
+traversal to a specific model snapshot when requested.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Correctness — Contextual Tuples Through Graph Traversal
+
+Move contextual tuple handling from post-processing into the `Userset::This` branch of `reverse_expand_objects`.
+
+**Files:**
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs:1447-1473` (remove post-processing)
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs:1542-1584` (`Userset::This` branch)
+- Modify: `crates/rsfga-domain/src/resolver/types.rs` (add `contextual_tuples` to `ReverseExpandContext`)
+- Test: `crates/rsfga-domain/src/resolver/tests/resolver_tests.rs`
+
+**Step 1: Write failing test for computed-relation contextual tuples**
+
+```rust
+#[tokio::test]
+async fn test_list_objects_contextual_tuples_via_computed_relation() {
+    // Model: document type with "can_access" = union(viewer, editor)
+    // Stored tuple: user:alice viewer document:stored-doc
+    // Contextual tuple: user:alice editor document:ctx-doc
+    // Expected: list_objects for "can_access" returns both documents
+    // (currently only returns "stored-doc" because contextual tuple
+    //  post-processing only matches direct relation, not computed)
+
+    let tuple_reader = Arc::new(MockTupleReader::new());
+    let model_reader = Arc::new(MockModelReader::new());
+    tuple_reader.add_store("store1").await;
+
+    model_reader.add_type("store1", TypeDefinition {
+        type_name: "document".to_string(),
+        relations: vec![
+            RelationDefinition {
+                name: "viewer".to_string(),
+                userset: Userset::This,
+                type_constraints: vec![TypeConstraint::direct("user")],
+            },
+            RelationDefinition {
+                name: "editor".to_string(),
+                userset: Userset::This,
+                type_constraints: vec![TypeConstraint::direct("user")],
+            },
+            RelationDefinition {
+                name: "can_access".to_string(),
+                userset: Userset::Union {
+                    children: vec![
+                        Userset::ComputedUserset { relation: "viewer".to_string() },
+                        Userset::ComputedUserset { relation: "editor".to_string() },
+                    ],
+                },
+                type_constraints: vec![],
+            },
+        ],
+    }).await;
+
+    tuple_reader.add_tuple("store1", "document", "stored-doc", "viewer", "user", "alice", None).await;
+
+    let contextual_tuples = vec![ContextualTuple {
+        user: "user:alice".to_string(),
+        relation: "editor".to_string(),
+        object: "document:ctx-doc".to_string(),
+        condition_name: None,
+        condition_context: None,
+    }];
+
+    let request = ListObjectsRequest::with_context(
+        "store1", "user:alice", "can_access", "document",
+        contextual_tuples, Default::default(),
+    );
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+
+    assert!(result.objects.contains(&"document:stored-doc".to_string()));
+    assert!(result.objects.contains(&"document:ctx-doc".to_string()),
+        "Contextual tuple via computed relation (editor → can_access) should be found");
+    assert_eq!(result.objects.len(), 2);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cargo test --lib -p rsfga-domain -- test_list_objects_contextual_tuples_via_computed_relation
+```
+
+Expected: FAIL — `ctx-doc` not in results (contextual tuples only checked post-processing for direct "can_access" match, not via computed "editor").
+
+**Step 3: Add `contextual_tuples` to `ReverseExpandContext`**
+
+```rust
+pub(crate) struct ReverseExpandContext<'a> {
+    // ... existing fields ...
+    pub contextual_tuples: &'a [ContextualTuple],  // NEW
+}
+```
+
+Update construction in `list_objects_inner`.
+
+**Step 4: Add contextual tuple scanning to `Userset::This` branch**
+
+After the existing `get_objects_for_user` call and its processing (line ~1584), add:
+
+```rust
+// Also check contextual tuples for direct matches on this relation
+for ct in ctx.contextual_tuples.iter() {
+    if state.results.len() >= ctx.limit {
+        state.truncated = true;
+        break;
+    }
+    if ct.relation != relation {
+        continue;
+    }
+    // Check user match (direct or wildcard)
+    let user_matches = ct.user == ctx.user
+        || (ct.user.contains(':') && ct.user.ends_with(":*") && {
+            let ct_type = ct.user.split(':').next().unwrap_or("");
+            let user_type = ctx.user.split(':').next().unwrap_or("");
+            ct_type == user_type
+        });
+    if !user_matches {
+        continue;
+    }
+    if let Some((obj_type, _obj_id)) = ct.object.split_once(':') {
+        if obj_type == ctx.object_type && !state.seen.contains(&ct.object) {
+            // Evaluate condition if present
+            if ct.condition_name.is_some() {
+                let condition_ok = self
+                    .evaluate_condition(
+                        ctx.store_id,
+                        ct.condition_name.as_deref(),
+                        ct.condition_context.as_ref(),
+                        ctx.request_context,
+                    )
+                    .await?;
+                if !condition_ok {
+                    continue;
+                }
+            }
+            state.seen.insert(ct.object.clone());
+            state.results.push(ct.object.clone());
+        }
+    }
+}
+```
+
+**Step 5: Remove post-processing block**
+
+Remove lines 1447-1473 in `list_objects_inner` (the `for ct in request.contextual_tuples.iter()` block). The contextual tuples are now handled inside the graph traversal.
+
+**Step 6: Run all list_objects tests**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+```
+
+Expected: All pass, including the new computed-relation test AND all existing contextual tuple tests (which now exercise the in-traversal path instead of post-processing).
+
+**Step 7: Commit**
+
+```bash
+git add crates/rsfga-domain/
+git commit -m "[BEHAVIORAL] Thread contextual tuples through ListObjects graph traversal
+
+Move contextual tuple handling from post-processing into the Userset::This
+branch of reverse_expand_objects. This enables contextual tuples to be
+found via computed relations (e.g., can_access = viewer | editor).
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Correctness — TupleToUserset Userset Type Constraints
+
+Handle `group#member` type constraints properly in TupleToUserset resolution.
+
+**Files:**
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs` (TupleToUserset branch ~line 1626)
+- Test: `crates/rsfga-domain/src/resolver/tests/resolver_tests.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[tokio::test]
+async fn test_list_objects_ttu_with_userset_type_constraint() {
+    // Model:
+    //   group type: "member" relation (This)
+    //   document type: "parent" relation (This, type_constraint: group#member)
+    //                  "viewer" relation (TupleToUserset: tupleset=parent, computed=member)
+    //
+    // Tuples:
+    //   user:alice member group:eng
+    //   group:eng#member parent document:doc1
+    //
+    // Expected: list_objects("user:alice", "viewer", "document") returns ["document:doc1"]
+    // because alice is a member of group:eng, and group:eng#member is a parent of doc1,
+    // so alice gets viewer on doc1 via the TupleToUserset.
+
+    // ... setup MockTupleReader + MockModelReader ...
+
+    let result = resolver.list_objects(&request, 100).await.unwrap();
+    assert!(result.objects.contains(&"document:doc1".to_string()),
+        "Should find doc1 via userset type constraint group#member");
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Expected: FAIL — the current code strips `#member` from `group#member`, treating it as just `group`.
+
+**Step 3: Fix TupleToUserset branch**
+
+In the `TupleToUserset` branch (~line 1647), change the type constraint parsing:
+
+```rust
+// Current (broken):
+let parent_type = type_constraint.type_name.split('#').next().unwrap_or(&type_constraint.type_name);
+
+// Fixed: handle userset references
+let (parent_type, parent_relation) = if let Some((t, r)) = type_constraint.type_name.split_once('#') {
+    (t, Some(r))
+} else {
+    (type_constraint.type_name.as_str(), None)
+};
+```
+
+When `parent_relation` is `Some(rel)`, the algorithm must find parents via:
+1. Find objects of `parent_type` where the user has `parent_relation` (via `reverse_expand_objects` recursion or `get_objects_for_user`)
+2. Use those objects as parent IDs for the tupleset lookup (existing `get_objects_with_parents` call)
+
+When `parent_relation` is `None`, the existing logic applies unchanged.
+
+**Step 4: Run tests**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+```
+
+**Step 5: Commit**
+
+```bash
+git add crates/rsfga-domain/
+git commit -m "[BEHAVIORAL] Handle userset type constraints in TupleToUserset ListObjects
+
+When a TupleToUserset type constraint is a userset reference (e.g.,
+group#member), resolve the relation through the member relation instead
+of treating the entire constraint as a bare type.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Performance — Parallel Union/Intersection/Exclusion
+
+Replace sequential branch evaluation with concurrent execution.
+
+**Files:**
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs` (Union ~line 1788, Intersection ~line 1830, Exclusion ~line 1944)
+- Test: `crates/rsfga-domain/src/resolver/tests/resolver_tests.rs`
+
+**Step 1: Add `futures` import if not present**
+
+Ensure `use futures::stream::{FuturesUnordered, StreamExt};` is imported in `graph_resolver.rs`.
+
+**Step 2: Refactor `Union` branch to use `FuturesUnordered`**
+
+```rust
+Userset::Union { children } => {
+    let mut futures = FuturesUnordered::new();
+    for child in children {
+        let mut branch_state = state.fork();
+        futures.push(async move {
+            let result = self
+                .reverse_expand_objects(ctx, &mut branch_state, relation, child)
+                .await;
+            (result, branch_state)
+        });
+    }
+    while let Some((result, branch_state)) = futures.next().await {
+        match result {
+            Ok(()) => state.merge_union(branch_state),
+            Err(DomainError::DepthLimitExceeded { .. })
+            | Err(DomainError::CycleDetected { .. }) => {
+                state.truncated = true;
+                state.merge_union(branch_state); // keep partial results
+            }
+            Err(e) => return Err(e),
+        }
+        if state.results.len() >= ctx.limit {
+            state.truncated = true;
+            break;
+        }
+    }
+}
+```
+
+**Step 3: Refactor `Intersection` branch**
+
+Evaluate first child to get candidate set, then evaluate remaining children concurrently. Intersect results after all complete:
+
+```rust
+Userset::Intersection { children } => {
+    if children.is_empty() {
+        return Ok(());
+    }
+    // Evaluate first child to get candidate set
+    let mut first_state = state.fork();
+    match self.reverse_expand_objects(ctx, &mut first_state, relation, &children[0]).await {
+        Ok(()) => {}
+        Err(DomainError::DepthLimitExceeded { .. } | DomainError::CycleDetected { .. }) => {
+            state.truncated = true;
+            return Ok(());
+        }
+        Err(e) => return Err(e),
+    }
+
+    let mut candidates: HashSet<String> = first_state.results.into_iter().collect();
+    if first_state.truncated {
+        state.truncated = true;
+    }
+
+    // Evaluate remaining children concurrently
+    let mut futures = FuturesUnordered::new();
+    for child in &children[1..] {
+        let mut branch_state = state.fork();
+        futures.push(async move {
+            let result = self.reverse_expand_objects(ctx, &mut branch_state, relation, child).await;
+            (result, branch_state)
+        });
+    }
+    while let Some((result, branch_state)) = futures.next().await {
+        match result {
+            Ok(()) => {
+                let branch_objects: HashSet<String> = branch_state.results.into_iter().collect();
+                candidates.retain(|obj| branch_objects.contains(obj));
+                if branch_state.truncated {
+                    state.truncated = true;
+                }
+            }
+            Err(DomainError::DepthLimitExceeded { .. } | DomainError::CycleDetected { .. }) => {
+                state.truncated = true;
+                candidates.clear(); // conservative: can't guarantee intersection
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    for obj in candidates {
+        if !state.seen.contains(&obj) {
+            state.seen.insert(obj.clone());
+            state.results.push(obj);
+        }
+    }
+}
+```
+
+**Step 4: Refactor `Exclusion` branch**
+
+Use `tokio::join!` for concurrent evaluation:
+
+```rust
+Userset::Exclusion { base, subtract } => {
+    let mut base_state = state.fork();
+    let mut sub_state = state.fork();
+
+    let (base_result, sub_result) = tokio::join!(
+        self.reverse_expand_objects(ctx, &mut base_state, relation, base),
+        self.reverse_expand_objects(ctx, &mut sub_state, relation, subtract),
+    );
+
+    // Handle base errors
+    match base_result {
+        Ok(()) => {}
+        Err(DomainError::DepthLimitExceeded { .. } | DomainError::CycleDetected { .. }) => {
+            state.truncated = true;
+        }
+        Err(e) => return Err(e),
+    }
+
+    // Handle subtract errors (conservative: if subtract fails, include all base)
+    let subtract_objects: HashSet<String> = match sub_result {
+        Ok(()) => sub_state.results.into_iter().collect(),
+        Err(DomainError::DepthLimitExceeded { .. } | DomainError::CycleDetected { .. }) => {
+            state.truncated = true;
+            HashSet::new() // conservative: might over-include
+        }
+        Err(e) => return Err(e),
+    };
+
+    for obj in base_state.results {
+        if !subtract_objects.contains(&obj) && !state.seen.contains(&obj) {
+            state.seen.insert(obj.clone());
+            state.results.push(obj);
+        }
+    }
+    if base_state.truncated || sub_state.truncated {
+        state.truncated = true;
+    }
+}
+```
+
+**Step 5: Run all tests**
+
+```bash
+cargo test --lib -p rsfga-domain -- list_objects
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: All pass. The existing `test_list_objects_with_union_of_direct_and_tuple_to_userset`, `test_list_objects_with_exclusion_relation`, and `test_list_objects_with_intersection_relation` tests validate correctness.
+
+**Step 6: Commit**
+
+```bash
+git add crates/rsfga-domain/
+git commit -m "[BEHAVIORAL] Parallelize union/intersection/exclusion in ListObjects
+
+Use FuturesUnordered for concurrent branch evaluation in union and
+intersection, and tokio::join! for exclusion. Each branch gets a forked
+ReverseExpandState, merged after completion.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: StreamedListObjects — Proto + Domain + gRPC Handler
+
+Add the `StreamedListObjects` gRPC server-streaming endpoint.
+
+**Files:**
+- Modify: `crates/rsfga-api/proto/openfga/v1/openfga_service.proto` (add RPC + messages)
+- Modify: `crates/rsfga-api/proto/openfga/v1/openfga.proto` (add message types if needed)
+- Modify: `crates/rsfga-api/build.rs` (if proto compilation needs changes)
+- Modify: `crates/rsfga-domain/src/resolver/graph_resolver.rs` (add `list_objects_streamed`)
+- Modify: `crates/rsfga-api/src/grpc/service.rs` (add handler)
+- Test: `crates/rsfga-api/src/grpc/tests.rs`
+
+**Step 1: Add proto definitions**
+
+In `openfga_service.proto`, add the RPC in the `service OpenFGAService` block (after `ListObjects`):
+
+```protobuf
+// Stream objects a user has access to (server-streaming)
+rpc StreamedListObjects(StreamedListObjectsRequest) returns (stream StreamedListObjectsResponse);
+```
+
+Add message types (at end of proto or in `openfga.proto`):
+
+```protobuf
+message StreamedListObjectsRequest {
+  string store_id = 1;
+  string authorization_model_id = 2;
+  string type = 3;
+  string relation = 4;
+  string user = 5;
+  ContextualTupleKeys contextual_tuples = 6;
+  google.protobuf.Struct context = 7;
+  ConsistencyPreference consistency = 8;
+}
+
+message StreamedListObjectsResponse {
+  string object = 1;
+}
+```
+
+**Step 2: Rebuild protos**
+
+```bash
+cargo build -p rsfga-api
+```
+
+This triggers `build.rs` which compiles the proto. Expect compilation errors in `service.rs` because the trait now requires `streamed_list_objects`.
+
+**Step 3: Add `list_objects_streamed` to domain resolver**
+
+In `graph_resolver.rs`, add a method that sends results via an `mpsc::Sender`:
+
+```rust
+pub async fn list_objects_streamed(
+    &self,
+    request: &super::types::ListObjectsRequest,
+    tx: tokio::sync::mpsc::Sender<String>,
+    max_candidates: usize,
+) -> DomainResult<()> {
+    // Reuse list_objects_inner, then stream results
+    let result = self.list_objects_inner(request, max_candidates).await?;
+    for object in result.objects {
+        if tx.send(object).await.is_err() {
+            break; // client disconnected
+        }
+    }
+    Ok(())
+}
+```
+
+Note: A more efficient implementation would stream results as they're discovered (modifying `ReverseExpandState` to use a channel). For this milestone, collecting-then-streaming is simpler and correct. The optimization can be a follow-up.
+
+**Step 4: Add gRPC handler**
+
+In `service.rs`, implement the `streamed_list_objects` method on `OpenFgaGrpcService`:
+
+```rust
+type StreamedListObjectsStream = ReceiverStream<Result<StreamedListObjectsResponse, Status>>;
+
+async fn streamed_list_objects(
+    &self,
+    request: Request<StreamedListObjectsRequest>,
+) -> Result<Response<Self::StreamedListObjectsStream>, Status> {
+    let req = request.into_inner();
+
+    // Validation (same as list_objects)
+    // ... validate store_id, user, relation, type ...
+
+    // Parse contextual tuples and context (same as list_objects)
+    // ... same conversion logic ...
+
+    let mut list_request = DomainListObjectsRequest::with_context(
+        req.store_id, req.user, req.relation, req.r#type,
+        contextual_tuples, context,
+    );
+    list_request.authorization_model_id = if req.authorization_model_id.is_empty() {
+        None
+    } else {
+        Some(req.authorization_model_id)
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel(100);
+    let resolver = self.resolver.clone();
+
+    tokio::spawn(async move {
+        match resolver.list_objects_streamed(&list_request, tx.clone(), MAX_LIST_OBJECTS_CANDIDATES).await {
+            Ok(()) => {}
+            Err(e) => {
+                let _ = tx.send(Err(Status::internal(e.to_string()))).await;
+            }
+        }
+    });
+
+    // Transform String channel to StreamedListObjectsResponse channel
+    let (resp_tx, resp_rx) = tokio::sync::mpsc::channel(100);
+    tokio::spawn(async move {
+        while let Some(object) = rx.recv().await {
+            if resp_tx.send(Ok(StreamedListObjectsResponse { object })).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(Response::new(ReceiverStream::new(resp_rx)))
+}
+```
+
+(Implementation details will depend on exact generated trait signatures from tonic.)
+
+**Step 5: Write test**
+
+```rust
+#[tokio::test]
+async fn test_grpc_streamed_list_objects_returns_objects() {
+    // Setup store, model, tuples
+    // Call streamed_list_objects, collect stream into Vec
+    // Assert correct objects returned
+}
+```
+
+**Step 6: Run tests**
+
+```bash
+cargo test --workspace --exclude compatibility-tests
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+**Step 7: Commit**
+
+```bash
+git add crates/rsfga-api/ crates/rsfga-domain/
+git commit -m "[BEHAVIORAL] Add StreamedListObjects gRPC server-streaming endpoint
+
+Add the StreamedListObjects RPC to the proto definition and implement
+the gRPC handler. Results are streamed to the client as individual
+StreamedListObjectsResponse messages containing one object each.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Integration Tests and Compatibility Verification
+
+Ensure all compatibility tests pass and add integration tests for the new features.
+
+**Files:**
+- Test: `crates/rsfga-domain/src/resolver/tests/resolver_tests.rs` (additional edge cases)
+- Test: `crates/rsfga-api/src/grpc/tests.rs` (gRPC integration)
+- Test: `crates/compatibility-tests/` (verify Section 15 + Section 34)
+
+**Step 1: Add edge case tests**
+
+- `test_list_objects_contextual_tuples_with_wildcard_through_computed_relation`
+- `test_list_objects_contextual_tuples_with_condition_through_computed_relation`
+- `test_list_objects_parallel_union_produces_correct_results`
+- `test_list_objects_parallel_intersection_produces_correct_results`
+- `test_list_objects_parallel_exclusion_produces_correct_results`
+
+**Step 2: Run full test suite**
+
+```bash
+cargo test --workspace --exclude compatibility-tests
+cargo clippy --all-targets --all-features -- -D warnings
+cargo fmt --check
+```
+
+**Step 3: Run compatibility tests** (if OpenFGA Docker available)
+
+```bash
+# Start OpenFGA
+docker compose -f docker-compose.openfga.yml up -d
+
+# Run compatibility tests
+cargo test -p compatibility-tests -- test_section_15
+cargo test -p compatibility-tests -- test_section_34
+```
+
+**Step 4: Commit**
+
+```bash
+git add .
+git commit -m "[TEST] Add comprehensive tests for ListObjects Full Resolver
+
+Add edge case tests for contextual tuples through computed relations,
+parallel branch correctness, userset type constraints, authorization_model_id
+pinning, and StreamedListObjects integration.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Update CLAUDE.md and ROADMAP.md Status
+
+**Files:**
+- Modify: `CLAUDE.md` (update status section)
+- Modify: `docs/design/ROADMAP.md` (add Milestone 1.16 section)
+
+**Step 1: Add Milestone 1.16 to ROADMAP.md**
+
+Add a section for Milestone 1.16: ListObjects Full Resolver with all tasks marked complete.
+
+**Step 2: Update CLAUDE.md**
+
+Update the "Current Status" section to include Milestone 1.16 completion.
+
+**Step 3: Commit**
+
+```bash
+git add CLAUDE.md docs/design/ROADMAP.md
+git commit -m "[DOCS] Update status for Milestone 1.16 ListObjects Full Resolver
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## PR Strategy
+
+Create a single PR covering all tasks, or split into smaller PRs:
+
+**Option A (recommended):** Two PRs:
+1. **PR 1**: Tasks 1-5 (structural refactoring + all correctness/performance fixes)
+2. **PR 2**: Tasks 6-8 (StreamedListObjects + tests + docs)
+
+**Option B:** One PR for everything.
+
+---
+
+## Summary of Tasks
+
+| Task | Type | Description | Estimated Steps |
+|------|------|-------------|-----------------|
+| 1 | Structural | Extract ReverseExpandContext/State | 7 |
+| 2 | Behavioral | authorization_model_id support | 10 |
+| 3 | Behavioral | Contextual tuples through traversal | 7 |
+| 4 | Behavioral | TupleToUserset userset type constraints | 5 |
+| 5 | Behavioral | Parallel union/intersection/exclusion | 6 |
+| 6 | Behavioral | StreamedListObjects proto + handler | 7 |
+| 7 | Test | Integration + compatibility tests | 4 |
+| 8 | Docs | Status updates | 3 |


### PR DESCRIPTION
## Summary

Addresses 6 gaps in ListObjects compared to OpenFGA behavior:

- **Structural refactoring**: Extract `ReverseExpandContext` (immutable) and `ReverseExpandState` (mutable, forkable) from the 14-parameter `reverse_expand_objects` function
- **`authorization_model_id` support**: Thread through HTTP, gRPC, domain, and resolver layers so ListObjects can pin a specific model version
- **Contextual tuples through graph traversal**: Move scanning into `Userset::This` branch so contextual tuples are discovered through computed relations (e.g., `can_access = viewer | editor`)
- **Userset type constraint handling**: Parse `group#member` type constraints correctly in TupleToUserset, using the specified relation for parent resolution
- **Parallel branches**: Union and Intersection use `futures::future::join_all`; Exclusion uses `tokio::join!` for concurrent evaluation
- **StreamedListObjects gRPC endpoint**: Server-streaming RPC with proto definitions, domain streaming method, and gRPC handler using `ReceiverStream`

Result caching is intentionally deferred to a future milestone.

## Test plan

- [x] 20 ListObjects unit tests pass (15 original + 5 new)
- [x] Full workspace: 1,566 tests pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StreamedListObjects gRPC endpoint for server-streaming object results.
  * ListObjects supports optional authorization model pinning.

* **Refactor**
  * Resolver traversal reworked with request/context state to enable parallel branch evaluation, better contextual-tuple handling, and robust truncation/deduplication.

* **Documentation**
  * ROADMAP and design docs updated with Phase 3 and Milestone 1.16 status.

* **Tests**
  * Large expansion of resolver tests covering authorization_model_id, contextual tuples, and branch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->